### PR TITLE
test the mips64 targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       os: osx
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=mips-unknown-linux-gnu
+    - env: TARGET=mips64-unknown-linux-gnuabi64
+    - env: TARGET=mips64el-unknown-linux-gnuabi64
     - env: TARGET=mipsel-unknown-linux-gnu
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gcc \
+    gcc-mips64-linux-gnuabi64 \
+    libc6-dev \
+    libc6-dev-mips64-cross \
+    qemu-user-static
+RUN apt-get install -y --no-install-recommends qemu-system-mips
+ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
+    CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
+    QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
+    RUST_TEST_THREADS=1

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gcc \
+    gcc-mips64el-linux-gnuabi64 \
+    libc6-dev \
+    libc6-dev-mips64el-cross \
+    qemu-user-static
+ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc \
+    CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
+    QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
+    RUST_TEST_THREADS=1


### PR DESCRIPTION
These should be all the required changes I think but libloading can't be cross compiled for these new targets:

```
error: failed to run custom build command for `libloading v0.3.1`
process didn't exit successfully: `/target/debug/build/libloading-07147fe7fffab0b2/build-script-build`(exit code: 101)
--- stderr
thread 'main' panicked at 'could not get target info: TargetNotFound', ../src/libcore/result.rs:799
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

I've openend nagisa/rust_libloading#19 to track that. Wel'll have to wait until that's fixed.

cc @alexcrichton 