### PR TITLE
Add eh_unwind_resume lang item

### DIFF
--- a/compiler-rt/compiler-rt-cdylib/src/lib.rs
+++ b/compiler-rt/compiler-rt-cdylib/src/lib.rs
@@ -62,3 +62,5 @@ declare!(___powidf2, __powidf2);
 fn eh_personality() {}
 #[lang = "panic_fmt"]
 fn panic_fmt() {}
+#[lang = "eh_unwind_resume"]
+fn eh_unwind_resume() {}

--- a/src/bin/intrinsics.rs
+++ b/src/bin/intrinsics.rs
@@ -405,3 +405,7 @@ extern "C" fn eh_personality() {}
 #[cfg(not(test))]
 #[lang = "panic_fmt"]
 extern "C" fn panic_fmt() {}
+
+#[cfg(not(test))]
+#[lang = "eh_unwind_resume"]
+extern "C" fn eh_unwind_resume() {}


### PR DESCRIPTION
This is necessary for targets where the `custom_unwind_resume` flag is set.
