### PR TITLE
Fix apt 404s in Docker

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates \
-  gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-  qemu-user-static
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+    qemu-user-static
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates \
-  gcc-arm-linux-gnueabi libc6-dev-armel-cross qemu-user-static
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-arm-linux-gnueabi libc6-dev-armel-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates \
-  gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates \
-  gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc-multilib libc6-dev ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc-multilib libc6-dev ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        gcc libc6-dev ca-certificates \
-        gcc-mips-linux-gnu libc6-dev-mips-cross \
-        binfmt-support qemu-user-static qemu-system-mips
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-mips-linux-gnu libc6-dev-mips-cross \
+    binfmt-support qemu-user-static qemu-system-mips
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     libc6-dev \
     libc6-dev-mips64-cross \
     qemu-user-static \
-    apt-get install -y --no-install-recommends qemu-system-mips
+    qemu-system-mips
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mips64-linux-gnuabi64 \
     libc6-dev \
     libc6-dev-mips64-cross \
-    qemu-user-static
-RUN apt-get install -y --no-install-recommends qemu-system-mips
+    qemu-user-static \
+    apt-get install -y --no-install-recommends qemu-system-mips
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mips64el-linux-gnuabi64 \

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        gcc libc6-dev ca-certificates \
-        gcc-mipsel-linux-gnu libc6-dev-mipsel-cross \
-        binfmt-support qemu-user-static
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-mipsel-linux-gnu libc6-dev-mipsel-cross \
+    binfmt-support qemu-user-static
 
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        gcc libc6-dev qemu-user-static ca-certificates \
-        gcc-powerpc-linux-gnu libc6-dev-powerpc-cross \
-        qemu-system-ppc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev qemu-user-static ca-certificates \
+    gcc-powerpc-linux-gnu libc6-dev-powerpc-cross \
+    qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        gcc libc6-dev ca-certificates \
-        gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross \
-        binfmt-support qemu-user-static qemu-system-ppc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates \
+    gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross \
+    binfmt-support qemu-user-static qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        gcc libc6-dev qemu-user-static ca-certificates \
-        gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
-        qemu-system-ppc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev qemu-user-static ca-certificates \
+    gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
+    qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
     QEMU_CPU=POWER8 \

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
     bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
     bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
     bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
     bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc libc6-dev ca-certificates


### PR DESCRIPTION
`apt update` and `apt install` should be in the same Docker RUN statement, otherwise `apt update` will be cached and `apt install` will 404 if a package no longer exists.