### PR TITLE
Define VISIBILITY_HIDDEN when compiling objects

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,7 @@ fn main() {
             cfg.flag("-fvisibility=hidden");
             cfg.flag("-fomit-frame-pointer");
             cfg.flag("-ffreestanding");
+            cfg.define("VISIBILITY_HIDDEN", None);
         }
 
         // NOTE Most of the ARM intrinsics are written in assembly. Tell gcc which arch we are going to


### PR DESCRIPTION
Apparently compiler-rt passed this and we just forgot to. Fixes visibility of
some symbols on 32-bit Linux.