### PR TITLE
CI: use Xargo 0.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,13 @@ before_install:
   - test "$TRAVIS_OS_NAME" = "osx" || docker run --rm --privileged multiarch/qemu-user-static:register
 
 install:
-  - if case $TARGET in thumb*) false;; *) true;; esac; then
-      curl https://static.rust-lang.org/rustup.sh |
-      sh -s -- --add-target=$TARGET --disable-sudo -y --prefix=`rustc --print sysroot`;
-    fi
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
+  - source ~/.cargo/env
+  - case $TARGET in
+      x86_64-apple-darwin | x86_64-unknown-linux-gnu) ;;
+      thumbv*-none-eabi*) rustup component add rust-src ;;
+      *) rustup target add $TARGET;;
+    esac
 
 script:
   - cargo generate-lockfile

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
-RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
-    bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv6m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv6m_none_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
-RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
-    bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
-RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
-    bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_none_eabihf=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABIHF_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabihf=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
-RUN curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
-    bash -s -- --at /usr/bin --from japaric/xargo --for x86_64-unknown-linux-gnu --tag v0.1.13
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7m_none_eabi=arm-none-eabi-gcc \


### PR DESCRIPTION
this version uses the rust-src component that rustup installs instead
of fetching the source tarball from static.r-l.o, which sometimes went
wrong due to the fallible logic that Xargo 0.1.x used

r? @alexcrichton 

The issue is that we must now install rustup as well