### PR TITLE
by default, mark this crate as the #![compiler_builtins] crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ compiler-rt = { path = "compiler-rt" }
 [features]
 # Build the missing intrinsics from compiler-rt C source code
 c = []
+# Mark this crate as the #![compiler_builtins] crate
+compiler-builtins = []
+default = ["compiler-builtins"]
+rustbuild = ["compiler-builtins"]
 weak = ["rlibc/weak"]
 
 [workspace]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,5 @@ build: false
 test_script:
   - cargo build --target %TARGET%
   - cargo build --release --target %TARGET%
-  - cargo test --target %TARGET%
-  - cargo test --release --target %TARGET%
+  - cargo test --no-default-features --target %TARGET%
+  - cargo test --no-default-features --release --target %TARGET%

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,8 +7,8 @@ case $1 in
         xargo build --target $1 --release
         ;;
     *)
-        cargo test --target $1
-        cargo test --target $1 --release
+        cargo test --no-default-features --target $1
+        cargo test --no-default-features --target $1 --release
         ;;
 esac
 
@@ -18,7 +18,7 @@ case $1 in
         xargo build --features c --target $1 --bin intrinsics
         ;;
     *)
-        cargo build --features c --target $1 --bin intrinsics
+        cargo build --no-default-features --features c --target $1 --bin intrinsics
         ;;
 esac
 
@@ -26,12 +26,12 @@ esac
 # TODO(#79) fix the undefined references problem for debug-assertions+lto
 case $1 in
     thumb*)
-        RUSTFLAGS="-C debug-assertions=no -C link-arg=-nostartfiles" xargo rustc --features c --target $1 --bin intrinsics -- -C lto
-        xargo rustc --features c --target $1 --bin intrinsics --release -- -C lto
+        RUSTFLAGS="-C debug-assertions=no -C link-arg=-nostartfiles" xargo rustc --no-default-features --features c --target $1 --bin intrinsics -- -C lto
+        xargo rustc --no-default-features --features c --target $1 --bin intrinsics --release -- -C lto
         ;;
     *)
-        RUSTFLAGS="-C debug-assertions=no" cargo rustc --features c --target $1 --bin intrinsics -- -C lto
-        cargo rustc --features c --target $1 --bin intrinsics --release -- -C lto
+        RUSTFLAGS="-C debug-assertions=no" cargo rustc --no-default-features --features c --target $1 --bin intrinsics -- -C lto
+        cargo rustc --no-default-features --features c --target $1 --bin intrinsics --release -- -C lto
         ;;
 esac
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(stage0), deny(warnings))]
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(rustbuild, compiler_builtins)]
+#![cfg_attr(feature = "compiler-builtins", compiler_builtins)]
 #![crate_name = "compiler_builtins"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",


### PR DESCRIPTION
as this is how most users will want to use this crate

r? @alexcrichton 