### PR TITLE
bump rustc-cfg dependency to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "compiler_builtins"
 version = "0.1.0"
 
 [build-dependencies]
-rustc-cfg = "0.2.0"
+rustc-cfg = "0.3.0"
 gcc = "0.3.36"
 
 [dev-dependencies]


### PR DESCRIPTION
the older no longer works with recent nightlies as target_family
disappeared from `rustc --print cfg`'s output