### PR TITLE
CI: use a recent nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 cache: cargo
 dist: trusty
 language: rust
-# NOTE(nightly-2016-12-05) work around for rust-lang/rust#38281
-rust: nightly-2016-12-05
+rust: nightly
 services: docker
 sudo: required
 

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
+    sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv6m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv6m_none_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
+    sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
+    sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_none_eabihf=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABIHF_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabihf=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
 RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
-    sh -s -- --git japaric/xargo --tag v0.2.1 --target x86_64-unknown-linux-gnu --to /usr/bin
+    sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7m_none_eabi=arm-none-eabi-gcc \

--- a/src/bin/intrinsics.rs
+++ b/src/bin/intrinsics.rs
@@ -403,5 +403,6 @@ pub fn _Unwind_Resume() {}
 extern "C" fn eh_personality() {}
 
 #[cfg(not(test))]
+#[no_mangle]
 #[lang = "panic_fmt"]
 extern "C" fn panic_fmt() {}

--- a/src/bin/intrinsics.rs
+++ b/src/bin/intrinsics.rs
@@ -400,9 +400,10 @@ pub fn _Unwind_Resume() {}
 // Lang items
 #[cfg(not(test))]
 #[lang = "eh_personality"]
+#[no_mangle]
 extern "C" fn eh_personality() {}
 
 #[cfg(not(test))]
-#[no_mangle]
 #[lang = "panic_fmt"]
+#[no_mangle]
 extern "C" fn panic_fmt() {}


### PR DESCRIPTION
- add #[no_mangle] to the panic_fmt lang item to adjust to changes in
the visibility algorithm

- adjust to changes in the layout of Cargo's target directory

- use a newer Xargo to reduce the build time of the sysroot (only core
is compiled as part of the sysroot now)

r? @alexcrichton