### PR TITLE
fix the build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ macro_rules! srem {
 }
 
 #[cfg(test)]
-#[macro_use]
+#[cfg_attr(target_arch = "arm", macro_use)]
 extern crate quickcheck;
 
 #[cfg(test)]


### PR DESCRIPTION
the unused macro_use crate lint has tightened; fix the new warnings