### PR TITLE
fix infinite recursion in divmoddi4 / mulodi4

### DIFF
--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -55,7 +55,9 @@ macro_rules! divmod {
                 #[cfg(all(feature = "c", any(target_arch = "x86")))]
                 () => unsafe { $div(a, b) },
             };
-            *rem = a - (r * b);
+            // NOTE won't overflow because it's using the result from the
+            // previous division
+            *rem = a - r.wrapping_mul(b);
             r
         }
     }


### PR DESCRIPTION
on ARMv7-M processors, divmoddi4 was calling mulodi4 and mulodi4 was calling
divmoddi4 leading to infinite recursion. This commit breaks the cycle by using
wrapping multiplication in divmoddi4.

fixes #145

r? @alexcrichton