### PR TITLE
remove unused macros

### DIFF
--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -1,17 +1,6 @@
 use float::Float;
 use int::Int;
 
-macro_rules! fp_overflow {
-    (infinity, $fty:ty, $sign: expr) => {
-        return {
-            <$fty as Float>::from_parts(
-                $sign,
-                <$fty as Float>::exponent_max() as <$fty as Float>::Int,
-                0 as <$fty as Float>::Int)
-        }
-    }
-}
-
 macro_rules! int_to_float {
     ($intrinsic:ident: $ity:ty, $fty:ty) => {
         int_to_float!($intrinsic: $ity, $fty, "C");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,21 +78,6 @@ macro_rules! urem {
     }
 }
 
-macro_rules! srem {
-    ($sty:ty, $a:expr, $b:expr) => {
-        unsafe {
-            let a = $a;
-            let b = $b;
-
-            if b == 0 || (b == -1 && a == $sty::min_value()) {
-                ::core::intrinsics::abort()
-            } else {
-                ::core::intrinsics::unchecked_rem(a, b)
-            }
-        }
-    }
-}
-
 // Hack for LLVM expectations for ABI on windows
 #[cfg(all(windows, target_pointer_width="64"))]
 #[repr(simd)]


### PR DESCRIPTION
to fix warnings