### PR TITLE
Use the Rust implementation of udivsi3 on ARM

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4196,7 +4196,6 @@ mod c {
                     "arm/clzsi2.S",
                     "arm/comparesf2.S",
                     "arm/divmodsi4.S",
-                    "arm/divsi3.S",
                     "arm/modsi3.S",
                     "arm/switch16.S",
                     "arm/switch32.S",
@@ -4204,8 +4203,20 @@ mod c {
                     "arm/switchu8.S",
                     "arm/sync_synchronize.S",
                     "arm/udivmodsi4.S",
-                    "arm/udivsi3.S",
                     "arm/umodsi3.S",
+
+                    // Exclude these two files for now even though we haven't
+                    // translated their implementation into Rust yet (#173).
+                    // They appear... buggy? The `udivsi3` implementation was
+                    // the one that seemed buggy, but the `divsi3` file
+                    // references a symbol from `udivsi3` so we compile them
+                    // both with the Rust versions.
+                    //
+                    // Note that if these are added back they should be removed
+                    // from thumbv6m below.
+                    //
+                    // "arm/divsi3.S",
+                    // "arm/udivsi3.S",
                 ],
             );
         }
@@ -4315,14 +4326,12 @@ mod c {
                     "clzsi2",
                     "comparesf2",
                     "divmodsi4",
-                    "divsi3",
                     "modsi3",
                     "switch16",
                     "switch32",
                     "switch8",
                     "switchu8",
                     "udivmodsi4",
-                    "udivsi3",
                     "umodsi3",
                 ],
             );

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -57,7 +57,6 @@ impl Divmod for i32 {}
 impl Divmod for i64 {}
 
 intrinsics! {
-    #[use_c_shim_if(all(target_arch = "arm", not(target_os = "ios"), not(thumbv6m)))]
     #[arm_aeabi_alias = __aeabi_idiv]
     pub extern "C" fn __divsi3(a: i32, b: i32) -> i32 {
         a.div(b)

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -148,9 +148,6 @@ macro_rules! udivmod_inner {
 }
 
 intrinsics! {
-    #[use_c_shim_if(all(target_arch = "arm",
-                        not(target_os = "ios"),
-                        not(thumbv6m)))]
     #[arm_aeabi_alias = __aeabi_uidiv]
     /// Returns `n / d`
     pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {


### PR DESCRIPTION
Although compiler-rt presumably has a more optimized implementation written in
assembly, it appears buggy for whatever reason, causing #173.

For now let's see if integration into rust-lang/rust will work with the
Rust-defined implementation!