### PR TITLE
Tweak definition of probestack functions

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -93,6 +93,7 @@ for rlib in $(echo $path); do
       uniq -d | \
       grep -v __x86.get_pc_thunk | \
       grep -v __builtin_cl | \
+      grep -v __builtin_ctz | \
       grep 'T __'
 
     if test $? = 0; then

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -13,6 +13,8 @@
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(i128_type)]
+#![feature(global_allocator)]
+#![feature(allocator_api)]
 #![cfg_attr(windows, feature(panic_unwind))]
 #![no_std]
 
@@ -21,6 +23,10 @@ extern crate alloc_system;
 extern crate compiler_builtins;
 #[cfg(windows)]
 extern crate panic_unwind;
+
+#[cfg(not(thumb))]
+#[global_allocator]
+static A: alloc_system::System = alloc_system::System;
 
 // NOTE cfg(not(thumbv6m)) means that the operation is not supported on ARMv6-M at all. Not even
 // compiler-rt provides a C/assembly implementation.

--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -112,8 +112,9 @@ intrinsics! {
         int_to_float!(i, u32, f64)
     }
 
-    #[use_c_shim_if(all(any(target_arch = "x86", target_arch = "x86_64"),
-                        not(windows)))]
+    #[use_c_shim_if(all(not(target_env = "msvc"),
+                        any(target_arch = "x86",
+                            all(not(windows), target_arch = "x86_64"))))]
     #[arm_aeabi_alias = __aeabi_ul2d]
     pub extern "C" fn __floatundidf(i: u64) -> f64 {
         int_to_float!(i, u64, f64)

--- a/src/probestack.rs
+++ b/src/probestack.rs
@@ -44,7 +44,7 @@
 #![cfg(not(windows))] // Windows already has builtins to do this
 
 #[naked]
-#[no_mangle]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 #[cfg(target_arch = "x86_64")]
 pub unsafe extern fn __rust_probestack() {
     // Our goal here is to touch each page between %rsp+8 and %rsp+8-%rax,
@@ -87,7 +87,7 @@ pub unsafe extern fn __rust_probestack() {
 }
 
 #[naked]
-#[no_mangle]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 #[cfg(target_arch = "x86")]
 pub unsafe extern fn __rust_probestack() {
     // This is the same as x86_64 above, only translated for 32-bit sizes. Note

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -10,7 +10,7 @@ use core::intrinsics;
 
 #[cfg(windows)]
 #[naked]
-#[no_mangle]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk_ms() {
     asm!("push   %rcx
           push   %rax
@@ -34,7 +34,7 @@ pub unsafe fn ___chkstk_ms() {
 
 #[cfg(windows)]
 #[naked]
-#[no_mangle]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn __alloca() {
     asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx
           jmp    ___chkstk  // Jump to ___chkstk since fallthrough may be unreliable");
@@ -43,7 +43,7 @@ pub unsafe fn __alloca() {
 
 #[cfg(windows)]
 #[naked]
-#[no_mangle]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk() {
     asm!("push   %rcx
           cmp    $$0x1000,%rax


### PR DESCRIPTION
It looks like the old `__rust_probestack` routine is incompatible with newer
linux kernels. My best guess for this is that the kernel's auto-growth logic is
failing to trigger, causing what looks like a legitimate segfault to get
delivered. My best guess for why *that's* happening is that the faulting address
is below `%rsp`, whereas previously all faulting stack addresses were above
`%rsp`. The probestack routine does not modify `%rsp` as it's probing the stack,
and presumably newer kernels are interpreting this as a legitimate violation.

This commit tweaks the probestack routine to instead update `%rsp` incrementally
as probing happens. The ABI of the function, however, requires that `%rsp`
isn't changed as part of the function so it's restored at the end to the
previous value.