### PR TITLE
Don't include custom chkstk on MSVC

### DIFF
--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -8,7 +8,7 @@ use core::intrinsics;
 // NOTE These functions are never mangled as they are not tested against compiler-rt
 // and mangling ___chkstk would break the `jmp ___chkstk` instruction in __alloca
 
-#[cfg(windows)]
+#[cfg(all(windows, target_env = "gnu"))]
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk_ms() {
@@ -32,7 +32,7 @@ pub unsafe fn ___chkstk_ms() {
     intrinsics::unreachable();
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, target_env = "gnu"))]
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn __alloca() {
@@ -41,7 +41,7 @@ pub unsafe fn __alloca() {
     intrinsics::unreachable();
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, target_env = "gnu"))]
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk() {


### PR DESCRIPTION
MSVC includes its own __chkstk so these aren't used.

These aren't included in compiler-rt: https://github.com/llvm-mirror/compiler-rt/blob/cb42103777b0fa8b8f38a7bfe5592ed8e3e48388/lib/builtins/CMakeLists.txt#L224-L284.
They also weren't included in compiler-builtins: https://github.com/rust-lang/rust/blob/1685c9298685f73db4fe890c1ed27b22408aaad7/src/libcompiler_builtins/build.rs#L255-L293 until rust-lang/rust#42899.