### PR TITLE
Avoid memcpy references in unoptimized code

### DIFF
--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -1,4 +1,3 @@
-use core::mem;
 use core::num::Wrapping;
 
 use float::Float;
@@ -75,7 +74,10 @@ macro_rules! add {
 
         // Swap a and b if necessary so that a has the larger absolute value.
         if b_abs > a_abs {
-            mem::swap(&mut a_rep, &mut b_rep);
+            // Don't use mem::swap because it may generate references to memcpy in unoptimized code.
+            let tmp = a_rep;
+            a_rep = b_rep;
+            b_rep = tmp;
         }
 
         // Extract the exponent and significand from the (possibly swapped) a and b.

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -125,7 +125,11 @@ macro_rules! udivmod_inner {
         // 1 <= sr <= u64::bits() - 1
         let mut carry = 0;
 
-        for _ in 0..sr {
+        // Don't use a range because they may generate references to memcpy in unoptimized code
+        let mut i = 0;
+        while i < sr {
+            i += 1;
+
             // r:q = ((r:q) << 1) | carry
             r = (r << 1) | (q >> (<$ty>::bits() - 1));
             q = (q << 1) | carry as $ty;
@@ -181,7 +185,12 @@ intrinsics! {
         let mut r = n >> sr;
 
         let mut carry = 0;
-        for _ in 0..sr {
+
+        // Don't use a range because they may generate references to memcpy in unoptimized code
+        let mut i = 0;
+        while i < sr {
+            i += 1;
+
             // r:q = ((r:q) << 1) | carry
             r = (r << 1) | (q >> (u32::bits() - 1));
             q = (q << 1) | carry;


### PR DESCRIPTION
Fixes rust-lang/rust#43411.