### PR TITLE
Update the gcc crate to 0.3.53 and disable compilation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rand = { version = "0.3.15", optional = true }
 
 [build-dependencies.gcc]
 optional = true
-version = "0.3.36"
+version = "0.3.53"
 
 [features]
 c = ["gcc"]

--- a/build.rs
+++ b/build.rs
@@ -4008,7 +4008,9 @@ mod c {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
 
-        let cfg = &mut gcc::Config::new();
+        let cfg = &mut gcc::Build::new();
+
+        cfg.warnings(false);
 
         if target_env == "msvc" {
             // Don't pull in extra libraries on MSVC


### PR DESCRIPTION
The update is needed because you'd otherwise get a deprecation warning about `Config` being deprecated, as rust-lang/rust has updated the gcc crate.

The compilation warnings are inside the compiler-rt submodule, about which we don't have
direct control over, so we disable them for the build to be silent.