### PR TITLE
Remove unused rustbuild feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ c = ["gcc"]
 compiler-builtins = []
 default = ["compiler-builtins"]
 mem = []
-rustbuild = ["compiler-builtins"]
 mangled-names = []
 
 # generate tests


### PR DESCRIPTION
I can't tell if this was ever used, but it's not used today.