### PR TITLE
Implement x86 chkstk in "rust"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ features = ["c"]
 - [x] floatunsisf.c
 - [ ] i386/ashldi3.S
 - [ ] i386/ashrdi3.S
-- [ ] i386/chkstk.S
-- [ ] i386/chkstk2.S
+- [x] i386/chkstk.S
+- [x] i386/chkstk2.S
 - [ ] i386/divdi3.S
 - [ ] i386/lshrdi3.S
 - [ ] i386/moddi3.S

--- a/build.rs
+++ b/build.rs
@@ -4176,8 +4176,6 @@ mod c {
                     &[
                         "i386/ashldi3.S",
                         "i386/ashrdi3.S",
-                        "i386/chkstk.S",
-                        "i386/chkstk2.S",
                         "i386/divdi3.S",
                         "i386/floatdidf.S",
                         "i386/floatdisf.S",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub mod mem;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
+#[cfg(target_arch = "x86")]
+pub mod x86;
+
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 

--- a/src/probestack.rs
+++ b/src/probestack.rs
@@ -44,8 +44,8 @@
 #![cfg(not(windows))] // Windows already has builtins to do this
 
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg(target_arch = "x86_64")]
+#[no_mangle]
+#[cfg(all(target_arch = "x86_64", not(feature = "mangled-names")))]
 pub unsafe extern fn __rust_probestack() {
     // Our goal here is to touch each page between %rsp+8 and %rsp+8-%rax,
     // ensuring that if any pages are unmapped we'll make a page fault.
@@ -87,8 +87,8 @@ pub unsafe extern fn __rust_probestack() {
 }
 
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[cfg(target_arch = "x86")]
+#[no_mangle]
+#[cfg(all(target_arch = "x86", not(feature = "mangled-names")))]
 pub unsafe extern fn __rust_probestack() {
     // This is the same as x86_64 above, only translated for 32-bit sizes. Note
     // that on Unix we're expected to restore everything as it was, this

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -8,9 +8,9 @@ use core::intrinsics;
 // NOTE These functions are never mangled as they are not tested against compiler-rt
 // and mangling ___chkstk would break the `jmp ___chkstk` instruction in __alloca
 
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk_ms() {
     asm!("
         push   %ecx
@@ -34,17 +34,17 @@ pub unsafe fn ___chkstk_ms() {
 }
 
 // FIXME: __alloca should be an alias to __chkstk
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn __alloca() {
     asm!("jmp ___chkstk   // Jump to ___chkstk since fallthrough may be unreliable");
     intrinsics::unreachable();
 }
 
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk() {
     asm!("
         push   %ecx

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,0 +1,71 @@
+#![allow(unused_imports)]
+
+use core::intrinsics;
+
+// NOTE These functions are implemented using assembly because they using a custom
+// calling convention which can't be implemented using a normal Rust function
+
+// NOTE These functions are never mangled as they are not tested against compiler-rt
+// and mangling ___chkstk would break the `jmp ___chkstk` instruction in __alloca
+
+#[cfg(all(windows, target_env = "gnu"))]
+#[naked]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+pub unsafe fn ___chkstk_ms() {
+    asm!("
+        push   %ecx
+        push   %eax
+        cmp    $$0x1000,%eax
+        lea    12(%esp),%ecx
+        jb     1f
+    2:
+        sub    $$0x1000,%ecx
+        test   %ecx,(%ecx)
+        sub    $$0x1000,%eax
+        cmp    $$0x1000,%eax
+        ja     2b
+    1:
+        sub    %eax,%ecx
+        test   %ecx,(%ecx)
+        pop    %eax
+        pop    %ecx
+        ret");
+    intrinsics::unreachable();
+}
+
+// FIXME: __alloca should be an alias to __chkstk
+#[cfg(all(windows, target_env = "gnu"))]
+#[naked]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+pub unsafe fn __alloca() {
+    asm!("jmp ___chkstk   // Jump to ___chkstk since fallthrough may be unreliable");
+    intrinsics::unreachable();
+}
+
+#[cfg(all(windows, target_env = "gnu"))]
+#[naked]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+pub unsafe fn ___chkstk() {
+    asm!("
+        push   %ecx
+        cmp    $$0x1000,%eax
+        lea    8(%esp),%ecx     // esp before calling this routine -> ecx
+        jb     1f
+    2:
+        sub    $$0x1000,%ecx
+        test   %ecx,(%ecx)
+        sub    $$0x1000,%eax
+        cmp    $$0x1000,%eax
+        ja     2b
+    1:
+        sub    %eax,%ecx
+        test   %ecx,(%ecx)
+
+        lea    4(%esp),%eax     // load pointer to the return address into eax
+        mov    %ecx,%esp        // install the new top of stack pointer into esp
+        mov    -4(%eax),%ecx    // restore ecx
+        push   (%eax)           // push return address onto the stack
+        sub    %esp,%eax        // restore the original value in eax
+        ret");
+    intrinsics::unreachable();
+}

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -12,23 +12,24 @@ use core::intrinsics;
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk_ms() {
-    asm!("push   %rcx
-          push   %rax
-          cmp    $$0x1000,%rax
-          lea    24(%rsp),%rcx
-          jb     1f
-          2:
-          sub    $$0x1000,%rcx
-          test   %rcx,(%rcx)
-          sub    $$0x1000,%rax
-          cmp    $$0x1000,%rax
-          ja     2b
-          1:
-          sub    %rax,%rcx
-          test   %rcx,(%rcx)
-          pop    %rax
-          pop    %rcx
-          ret");
+    asm!("
+        push   %rcx
+        push   %rax
+        cmp    $$0x1000,%rax
+        lea    24(%rsp),%rcx
+        jb     1f
+    2:
+        sub    $$0x1000,%rcx
+        test   %rcx,(%rcx)
+        sub    $$0x1000,%rax
+        cmp    $$0x1000,%rax
+        ja     2b
+    1:
+        sub    %rax,%rcx
+        test   %rcx,(%rcx)
+        pop    %rax
+        pop    %rcx
+        ret");
     intrinsics::unreachable();
 }
 
@@ -45,25 +46,26 @@ pub unsafe fn __alloca() {
 #[naked]
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 pub unsafe fn ___chkstk() {
-    asm!("push   %rcx
-          cmp    $$0x1000,%rax
-          lea    16(%rsp),%rcx  // rsp before calling this routine -> rcx
-          jb     1f
-          2:
-          sub    $$0x1000,%rcx
-          test   %rcx,(%rcx)
-          sub    $$0x1000,%rax
-          cmp    $$0x1000,%rax
-          ja     2b
-          1:
-          sub    %rax,%rcx
-          test   %rcx,(%rcx)
+    asm!("
+        push   %rcx
+        cmp    $$0x1000,%rax
+        lea    16(%rsp),%rcx  // rsp before calling this routine -> rcx
+        jb     1f
+    2:
+        sub    $$0x1000,%rcx
+        test   %rcx,(%rcx)
+        sub    $$0x1000,%rax
+        cmp    $$0x1000,%rax
+        ja     2b
+    1:
+        sub    %rax,%rcx
+        test   %rcx,(%rcx)
 
-          lea    8(%rsp),%rax   // load pointer to the return address into rax
-          mov    %rcx,%rsp      // install the new top of stack pointer into rsp
-          mov    -8(%rax),%rcx  // restore rcx
-          push   (%rax)         // push return address onto the stack
-          sub    %rsp,%rax      // restore the original value in rax
-          ret");
+        lea    8(%rsp),%rax   // load pointer to the return address into rax
+        mov    %rcx,%rsp      // install the new top of stack pointer into rsp
+        mov    -8(%rax),%rcx  // restore rcx
+        push   (%rax)         // push return address onto the stack
+        sub    %rsp,%rax      // restore the original value in rax
+        ret");
     intrinsics::unreachable();
 }

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -8,9 +8,9 @@ use core::intrinsics;
 // NOTE These functions are never mangled as they are not tested against compiler-rt
 // and mangling ___chkstk would break the `jmp ___chkstk` instruction in __alloca
 
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk_ms() {
     asm!("
         push   %rcx
@@ -33,18 +33,18 @@ pub unsafe fn ___chkstk_ms() {
     intrinsics::unreachable();
 }
 
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn __alloca() {
     asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx
           jmp    ___chkstk  // Jump to ___chkstk since fallthrough may be unreliable");
     intrinsics::unreachable();
 }
 
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "mangled-names")))]
 #[naked]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk() {
     asm!("
         push   %rcx


### PR DESCRIPTION
cc #183 

Basically the same as the x86_64 ones, except `__alloca` doesn't need to fix the parameter register. I've manually verified that the disassembly is the same, and that these work in a compiled rust program.

The second commit disables compiling probestack functions for `feature = mangled-names`. They aren't needed during testing because they aren't comparison tested and the unmangled versions are the ones that actually get used.

r? @alexcrichton