### PR TITLE
Partial revert of the float conversion refactor in #192

### DIFF
--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -1,5 +1,5 @@
 use float::Float;
-use int::{Int, CastInto};
+use int::Int;
 
 macro_rules! int_to_float {
     ($i:expr, $ity:ty, $fty:ty) => ({
@@ -137,116 +137,115 @@ enum Sign {
     Negative
 }
 
-fn float_to_int<F: Float, I: Int>(f: F) -> I where
-    F::Int: CastInto<u32>,
-    F::Int: CastInto<I>,
-{
-    let f = f;
-    let fixint_min = I::min_value();
-    let fixint_max = I::max_value();
-    let fixint_bits = I::BITS;
-    let fixint_unsigned = fixint_min == I::ZERO;
+macro_rules! float_to_int {
+    ($f:expr, $fty:ty, $ity:ty) => ({
+        let f = $f;
+        let fixint_min = <$ity>::min_value();
+        let fixint_max = <$ity>::max_value();
+        let fixint_bits = <$ity>::BITS as usize;
+        let fixint_unsigned = fixint_min == 0;
 
-    let sign_bit = F::SIGN_MASK;
-    let significand_bits = F::SIGNIFICAND_BITS;
-    let exponent_bias = F::EXPONENT_BIAS;
-    //let exponent_max = F::exponent_max() as usize;
+        let sign_bit = <$fty>::SIGN_MASK;
+        let significand_bits = <$fty>::SIGNIFICAND_BITS as usize;
+        let exponent_bias = <$fty>::EXPONENT_BIAS as usize;
+        //let exponent_max = <$fty>::exponent_max() as usize;
 
-    // Break a into sign, exponent, significand
-    let a_rep = F::repr(f);
-    let a_abs = a_rep & !sign_bit;
+        // Break a into sign, exponent, significand
+        let a_rep = <$fty>::repr(f);
+        let a_abs = a_rep & !sign_bit;
 
-    // this is used to work around -1 not being available for unsigned
-    let sign = if (a_rep & sign_bit) == F::Int::ZERO { Sign::Positive } else { Sign::Negative };
-    let mut exponent: u32 = (a_abs >> significand_bits).cast();
-    let significand = (a_abs & F::SIGNIFICAND_MASK) | F::IMPLICIT_BIT;
+        // this is used to work around -1 not being available for unsigned
+        let sign = if (a_rep & sign_bit) == 0 { Sign::Positive } else { Sign::Negative };
+        let mut exponent = (a_abs >> significand_bits) as usize;
+        let significand = (a_abs & <$fty>::SIGNIFICAND_MASK) | <$fty>::IMPLICIT_BIT;
 
-    // if < 1 or unsigned & negative
-    if exponent < exponent_bias ||
-        fixint_unsigned && sign == Sign::Negative {
-        return I::ZERO;
-    }
-    exponent -= exponent_bias;
+        // if < 1 or unsigned & negative
+        if  exponent < exponent_bias ||
+            fixint_unsigned && sign == Sign::Negative {
+            return 0
+        }
+        exponent -= exponent_bias;
 
-    // If the value is infinity, saturate.
-    // If the value is too large for the integer type, 0.
-    if exponent >= (if fixint_unsigned {fixint_bits} else {fixint_bits -1}) {
-        return if sign == Sign::Positive {fixint_max} else {fixint_min}
-    }
-    // If 0 <= exponent < significand_bits, right shift to get the result.
-    // Otherwise, shift left.
-    // (sign - 1) will never overflow as negative signs are already returned as 0 for unsigned
-    let r: I = if exponent < significand_bits {
-        (significand >> (significand_bits - exponent)).cast()
-    } else {
-        (significand << (exponent - significand_bits)).cast()
-    };
+        // If the value is infinity, saturate.
+        // If the value is too large for the integer type, 0.
+        if exponent >= (if fixint_unsigned {fixint_bits} else {fixint_bits -1}) {
+            return if sign == Sign::Positive {fixint_max} else {fixint_min}
+        }
+        // If 0 <= exponent < significand_bits, right shift to get the result.
+        // Otherwise, shift left.
+        // (sign - 1) will never overflow as negative signs are already returned as 0 for unsigned
+        let r = if exponent < significand_bits {
+            (significand >> (significand_bits - exponent)) as $ity
+        } else {
+            (significand as $ity) << (exponent - significand_bits)
+        };
 
-    if sign == Sign::Negative {
-        (!r).wrapping_add(I::ONE)
-    } else {
-        r
-    }
+        if sign == Sign::Negative {
+            (!r).wrapping_add(1)
+        } else {
+            r
+        }
+    })
 }
 
 intrinsics! {
     #[arm_aeabi_alias = __aeabi_f2iz]
     pub extern "C" fn __fixsfsi(f: f32) -> i32 {
-        float_to_int(f)
+        float_to_int!(f, f32, i32)
     }
 
     #[arm_aeabi_alias = __aeabi_f2lz]
     pub extern "C" fn __fixsfdi(f: f32) -> i64 {
-        float_to_int(f)
+        float_to_int!(f, f32, i64)
     }
 
     #[unadjusted_on_win64]
     pub extern "C" fn __fixsfti(f: f32) -> i128 {
-        float_to_int(f)
+        float_to_int!(f, f32, i128)
     }
 
     #[arm_aeabi_alias = __aeabi_d2iz]
     pub extern "C" fn __fixdfsi(f: f64) -> i32 {
-        float_to_int(f)
+        float_to_int!(f, f64, i32)
     }
 
     #[arm_aeabi_alias = __aeabi_d2lz]
     pub extern "C" fn __fixdfdi(f: f64) -> i64 {
-        float_to_int(f)
+        float_to_int!(f, f64, i64)
     }
 
     #[unadjusted_on_win64]
     pub extern "C" fn __fixdfti(f: f64) -> i128 {
-        float_to_int(f)
+        float_to_int!(f, f64, i128)
     }
 
     #[arm_aeabi_alias = __aeabi_f2uiz]
     pub extern "C" fn __fixunssfsi(f: f32) -> u32 {
-        float_to_int(f)
+        float_to_int!(f, f32, u32)
     }
 
     #[arm_aeabi_alias = __aeabi_f2ulz]
     pub extern "C" fn __fixunssfdi(f: f32) -> u64 {
-        float_to_int(f)
+        float_to_int!(f, f32, u64)
     }
 
     #[unadjusted_on_win64]
     pub extern "C" fn __fixunssfti(f: f32) -> u128 {
-        float_to_int(f)
+        float_to_int!(f, f32, u128)
     }
 
     #[arm_aeabi_alias = __aeabi_d2uiz]
     pub extern "C" fn __fixunsdfsi(f: f64) -> u32 {
-        float_to_int(f)
+        float_to_int!(f, f64, u32)
     }
 
     #[arm_aeabi_alias = __aeabi_d2ulz]
     pub extern "C" fn __fixunsdfdi(f: f64) -> u64 {
-        float_to_int(f)
+        float_to_int!(f, f64, u64)
     }
 
     #[unadjusted_on_win64]
     pub extern "C" fn __fixunsdfti(f: f64) -> u128 {
-        float_to_int(f)
+        float_to_int!(f, f64, u128)
     }
 }


### PR DESCRIPTION
PR to make updating compiler-builtins for newer rustc possible again (cc #197). I don't really know what #197 is about yet, so I want to un-block updates of compiler-builtins by reverting the conversion implementation to its older macro form. The other changes of #192 are left, even the changes to `mod.rs` done by the two partially reverted commits.

I've tested the changes of this PR with a local build of rustc and it can't reproduce #197. However, it does not close the issue, as optimally we'd have the code back in master again.

r? @alexcrichton 