### PR TITLE
Remove redundant rerun-if-changed directive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,6 @@
 use std::env;
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
     let target = env::var("TARGET").unwrap();
 
     // Emscripten's runtime includes all the builtins


### PR DESCRIPTION
The docs at doc.crates.io/build-script.html state:

> Note that if the build script itself (or one of its dependencies)
> changes, then it's rebuilt and rerun unconditionally, so
> cargo:rerun-if-changed=build.rs is almost always redundant (unless you
> want to ignore changes in all other files except for build.rs).

So remove this redundant thing.

r? @alexcrichton 