### PR TITLE
drop binfmt_misc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ matrix:
       os: osx
     - env: TARGET=x86_64-unknown-linux-gnu
 
-before_install:
-  - test "$TRAVIS_OS_NAME" = "osx" || docker run --rm --privileged multiarch/qemu-user-static:register
-
 install:
   - case $TARGET in
       x86_64-apple-darwin | x86_64-unknown-linux-gnu) ;;

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -5,5 +5,6 @@ RUN apt-get update && \
     gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
     qemu-user-static
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-aarch64-static \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabi libc6-dev-armel-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER=qemu-arm-static \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
     RUST_TEST_THREADS=1
-

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -4,5 +4,6 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm-static \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -4,5 +4,6 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm-static \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update && \
     binfmt-support qemu-user-static qemu-system-mips
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER=qemu-mips-static \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     qemu-user-static \
     qemu-system-mips
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64-static \
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     libc6-dev-mips64el-cross \
     qemu-user-static
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64el-static \
     CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
     QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update && \
     binfmt-support qemu-user-static
 
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER=qemu-mipsel-static \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update && \
     qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
+    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc-static \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     binfmt-support qemu-user-static qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
+    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64-static \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
     QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64le-static \
     QEMU_CPU=POWER8 \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/thumbv6m-linux-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-linux-eabi/Dockerfile
@@ -6,4 +6,5 @@ RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv6m_linux_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV6M_LINUX_EABI_LINKER=arm-none-eabi-gcc \
+    CARGO_TARGET_THUMBV6M_LINUX_EABI_RUNNER=qemu-arm-static \
     CC_thumbv6m_linux_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-linux-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-linux-eabi/Dockerfile
@@ -6,4 +6,5 @@ RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_linux_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_LINUX_EABI_LINKER=arm-none-eabi-gcc \
+    CARGO_TARGET_THUMBV7EM_LINUX_EABI_RUNNER=qemu-arm-static \
     CC_thumbv7em_linux_eabi=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7em-linux-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-linux-eabihf/Dockerfile
@@ -6,4 +6,5 @@ RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7em_linux_eabihf=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_LINUX_EABIHF_LINKER=arm-none-eabi-gcc \
+    CARGO_TARGET_THUMBV7EM_LINUX_EABIHF_RUNNER=qemu-arm-static \
     CC_thumbv7em_linux_eabihf=arm-none-eabi-gcc \

--- a/ci/docker/thumbv7m-linux-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-linux-eabi/Dockerfile
@@ -6,4 +6,5 @@ RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin
 ENV AR_thumbv7m_linux_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7M_LINUX_EABI_LINKER=arm-none-eabi-gcc \
+    CARGO_TARGET_THUMBV7M_LINUX_EABI_RUNNER=qemu-arm-static \
     CC_thumbv7m_linux_eabi=arm-none-eabi-gcc \


### PR DESCRIPTION
Instead use the Cargo runner feature. The binfmt_misc approach requires running a privileged
container for setup. Not all docker setups support privileged containers so the test suite should be
more accessible with this change as no privileged container is needed.

r? @alexcrichton