### PR TITLE
Fix nightly CI

### DIFF
--- a/src/int/addsub.rs
+++ b/src/int/addsub.rs
@@ -79,44 +79,46 @@ trait Subo: AddSub
 impl Subo for i128 {}
 impl Subo for u128 {}
 
-#[cfg_attr(not(stage0), lang = "i128_add")]
-pub fn rust_i128_add(a: i128, b: i128) -> i128 {
-    rust_u128_add(a as _, b as _) as _
-}
-#[cfg_attr(not(stage0), lang = "i128_addo")]
-pub fn rust_i128_addo(a: i128, b: i128) -> (i128, bool) {
-    let mut oflow = 0;
-    let r = a.addo(b, &mut oflow);
-    (r, oflow != 0)
-}
-#[cfg_attr(not(stage0), lang = "u128_add")]
-pub fn rust_u128_add(a: u128, b: u128) -> u128 {
-    a.add(b)
-}
-#[cfg_attr(not(stage0), lang = "u128_addo")]
-pub fn rust_u128_addo(a: u128, b: u128) -> (u128, bool) {
-    let mut oflow = 0;
-    let r = a.addo(b, &mut oflow);
-    (r, oflow != 0)
-}
+u128_lang_items! {
+    #[lang = "i128_add"]
+    pub fn rust_i128_add(a: i128, b: i128) -> i128 {
+        rust_u128_add(a as _, b as _) as _
+    }
+    #[lang = "i128_addo"]
+    pub fn rust_i128_addo(a: i128, b: i128) -> (i128, bool) {
+        let mut oflow = 0;
+        let r = a.addo(b, &mut oflow);
+        (r, oflow != 0)
+    }
+    #[lang = "u128_add"]
+    pub fn rust_u128_add(a: u128, b: u128) -> u128 {
+        a.add(b)
+    }
+    #[lang = "u128_addo"]
+    pub fn rust_u128_addo(a: u128, b: u128) -> (u128, bool) {
+        let mut oflow = 0;
+        let r = a.addo(b, &mut oflow);
+        (r, oflow != 0)
+    }
 
-#[cfg_attr(not(stage0), lang = "i128_sub")]
-pub fn rust_i128_sub(a: i128, b: i128) -> i128 {
-    rust_u128_sub(a as _, b as _) as _
-}
-#[cfg_attr(not(stage0), lang = "i128_subo")]
-pub fn rust_i128_subo(a: i128, b: i128) -> (i128, bool) {
-    let mut oflow = 0;
-    let r = a.subo(b, &mut oflow);
-    (r, oflow != 0)
-}
-#[cfg_attr(not(stage0), lang = "u128_sub")]
-pub fn rust_u128_sub(a: u128, b: u128) -> u128 {
-    a.sub(b)
-}
-#[cfg_attr(not(stage0), lang = "u128_subo")]
-pub fn rust_u128_subo(a: u128, b: u128) -> (u128, bool) {
-    let mut oflow = 0;
-    let r = a.subo(b, &mut oflow);
-    (r, oflow != 0)
+    #[lang = "i128_sub"]
+    pub fn rust_i128_sub(a: i128, b: i128) -> i128 {
+        rust_u128_sub(a as _, b as _) as _
+    }
+    #[lang = "i128_subo"]
+    pub fn rust_i128_subo(a: i128, b: i128) -> (i128, bool) {
+        let mut oflow = 0;
+        let r = a.subo(b, &mut oflow);
+        (r, oflow != 0)
+    }
+    #[lang = "u128_sub"]
+    pub fn rust_u128_sub(a: u128, b: u128) -> u128 {
+        a.sub(b)
+    }
+    #[lang = "u128_subo"]
+    pub fn rust_u128_subo(a: u128, b: u128) -> (u128, bool) {
+        let mut oflow = 0;
+        let r = a.subo(b, &mut oflow);
+        (r, oflow != 0)
+    }
 }

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -108,23 +108,25 @@ intrinsics! {
     }
 }
 
-#[cfg_attr(not(stage0), lang = "i128_mul")]
-pub fn rust_i128_mul(a: i128, b: i128) -> i128 {
-    __multi3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "i128_mulo")]
-pub fn rust_i128_mulo(a: i128, b: i128) -> (i128, bool) {
-    let mut oflow = 0;
-    let r = __muloti4(a, b, &mut oflow);
-    (r, oflow != 0)
-}
-#[cfg_attr(not(stage0), lang = "u128_mul")]
-pub fn rust_u128_mul(a: u128, b: u128) -> u128 {
-    __multi3(a as _, b as _) as _
-}
-#[cfg_attr(not(stage0), lang = "u128_mulo")]
-pub fn rust_u128_mulo(a: u128, b: u128) -> (u128, bool) {
-    let mut oflow = 0;
-    let r = a.mulo(b, &mut oflow);
-    (r, oflow != 0)
+u128_lang_items! {
+    #[lang = "i128_mul"]
+    pub fn rust_i128_mul(a: i128, b: i128) -> i128 {
+        __multi3(a, b)
+    }
+    #[lang = "i128_mulo"]
+    pub fn rust_i128_mulo(a: i128, b: i128) -> (i128, bool) {
+        let mut oflow = 0;
+        let r = __muloti4(a, b, &mut oflow);
+        (r, oflow != 0)
+    }
+    #[lang = "u128_mul"]
+    pub fn rust_u128_mul(a: u128, b: u128) -> u128 {
+        __multi3(a as _, b as _) as _
+    }
+    #[lang = "u128_mulo"]
+    pub fn rust_u128_mulo(a: u128, b: u128) -> (u128, bool) {
+        let mut oflow = 0;
+        let r = a.mulo(b, &mut oflow);
+        (r, oflow != 0)
+    }
 }

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -98,11 +98,13 @@ intrinsics! {
     }
 }
 
-#[cfg_attr(not(stage0), lang = "i128_div")]
-pub fn rust_i128_div(a: i128, b: i128) -> i128 {
-    __divti3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "i128_rem")]
-pub fn rust_i128_rem(a: i128, b: i128) -> i128 {
-    __modti3(a, b)
+u128_lang_items! {
+    #[lang = "i128_div"]
+    pub fn rust_i128_div(a: i128, b: i128) -> i128 {
+        __divti3(a, b)
+    }
+    #[lang = "i128_rem"]
+    pub fn rust_i128_rem(a: i128, b: i128) -> i128 {
+        __modti3(a, b)
+    }
 }

--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -96,36 +96,38 @@ intrinsics! {
     }
 }
 
-#[cfg_attr(not(stage0), lang = "i128_shl")]
-pub fn rust_i128_shl(a: i128, b: u32) -> i128 {
-    __ashlti3(a as _, b) as _
-}
-#[cfg_attr(not(stage0), lang = "i128_shlo")]
-pub fn rust_i128_shlo(a: i128, b: u128) -> (i128, bool) {
-    (rust_i128_shl(a, b as _), b >= 128)
-}
-#[cfg_attr(not(stage0), lang = "u128_shl")]
-pub fn rust_u128_shl(a: u128, b: u32) -> u128 {
-    __ashlti3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "u128_shlo")]
-pub fn rust_u128_shlo(a: u128, b: u128) -> (u128, bool) {
-    (rust_u128_shl(a, b as _), b >= 128)
-}
+u128_lang_items! {
+    #[lang = "i128_shl"]
+    pub fn rust_i128_shl(a: i128, b: u32) -> i128 {
+        __ashlti3(a as _, b) as _
+    }
+    #[lang = "i128_shlo"]
+    pub fn rust_i128_shlo(a: i128, b: u128) -> (i128, bool) {
+        (rust_i128_shl(a, b as _), b >= 128)
+    }
+    #[lang = "u128_shl"]
+    pub fn rust_u128_shl(a: u128, b: u32) -> u128 {
+        __ashlti3(a, b)
+    }
+    #[lang = "u128_shlo"]
+    pub fn rust_u128_shlo(a: u128, b: u128) -> (u128, bool) {
+        (rust_u128_shl(a, b as _), b >= 128)
+    }
 
-#[cfg_attr(not(stage0), lang = "i128_shr")]
-pub fn rust_i128_shr(a: i128, b: u32) -> i128 {
-    __ashrti3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "i128_shro")]
-pub fn rust_i128_shro(a: i128, b: u128) -> (i128, bool) {
-    (rust_i128_shr(a, b as _), b >= 128)
-}
-#[cfg_attr(not(stage0), lang = "u128_shr")]
-pub fn rust_u128_shr(a: u128, b: u32) -> u128 {
-    __lshrti3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "u128_shro")]
-pub fn rust_u128_shro(a: u128, b: u128) -> (u128, bool) {
-    (rust_u128_shr(a, b as _), b >= 128)
+    #[lang = "i128_shr"]
+    pub fn rust_i128_shr(a: i128, b: u32) -> i128 {
+        __ashrti3(a, b)
+    }
+    #[lang = "i128_shro"]
+    pub fn rust_i128_shro(a: i128, b: u128) -> (i128, bool) {
+        (rust_i128_shr(a, b as _), b >= 128)
+    }
+    #[lang = "u128_shr"]
+    pub fn rust_u128_shr(a: u128, b: u32) -> u128 {
+        __lshrti3(a, b)
+    }
+    #[lang = "u128_shro"]
+    pub fn rust_u128_shro(a: u128, b: u128) -> (u128, bool) {
+        (rust_u128_shr(a, b as _), b >= 128)
+    }
 }

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -270,11 +270,13 @@ intrinsics! {
     }
 }
 
-#[cfg_attr(not(stage0), lang = "u128_div")]
-pub fn rust_u128_div(a: u128, b: u128) -> u128 {
-    __udivti3(a, b)
-}
-#[cfg_attr(not(stage0), lang = "u128_rem")]
-pub fn rust_u128_rem(a: u128, b: u128) -> u128 {
-    __umodti3(a, b)
+u128_lang_items! {
+    #[lang = "u128_div"]
+    pub fn rust_u128_div(a: u128, b: u128) -> u128 {
+        __udivti3(a, b)
+    }
+    #[lang = "u128_rem"]
+    pub fn rust_u128_rem(a: u128, b: u128) -> u128 {
+        __umodti3(a, b)
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -280,3 +280,17 @@ pub mod win64_128bit_abi_hack {
         }
     }
 }
+
+macro_rules! u128_lang_items {
+    ($(
+        #[lang = $lang:tt]
+        pub fn $name:ident( $($argname:ident:  $ty:ty),* ) -> $ret:ty {
+            $($body:tt)*
+        }
+    )*) => ($(
+        #[cfg_attr(not(any(stage0, feature = "gen-tests")), lang = $lang)]
+        pub fn $name( $($argname:  $ty),* ) -> $ret {
+            $($body)*
+        }
+    )*)
+}


### PR DESCRIPTION
Currently we're getting lots of errors about duplicate lang items so deal with
this by `#[cfg_attr]`'ing off the lang item attribute in tests.