### PR TITLE
Fix __kuser_cmpxchg inline asm

### DIFF
--- a/src/arm_linux.rs
+++ b/src/arm_linux.rs
@@ -4,23 +4,12 @@ use core::mem;
 // Kernel-provided user-mode helper functions:
 // https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt
 unsafe fn __kuser_cmpxchg(oldval: u32, newval: u32, ptr: *mut u32) -> bool {
-    let out: u32;
-    // FIXME: we can't use BLX on ARMv4
-    asm!("blx ${0}"
-         : "={r0}" (out)
-         : "r" (0xffff0fc0u32)
-           "{r0}" (oldval),
-           "{r1}" (newval),
-           "{r2}" (ptr)
-         : "r3", "r12", "lr", "cc", "memory");
-    out == 0
+    let f: extern "C" fn (u32, u32, *mut u32) -> u32 = mem::transmute(0xffff0fc0u32);
+    f(oldval, newval, ptr) == 0
 }
 unsafe fn __kuser_memory_barrier() {
-    // FIXME: we can't use BLX on ARMv4
-    asm!("blx ${0}"
-         :
-         : "r" (0xffff0fa0u32)
-         : "lr", "memory");
+    let f: extern "C" fn () = mem::transmute(0xffff0fa0u32);
+    f();
 }
 
 // Word-align a pointer


### PR DESCRIPTION
The wrong register was passed to BLX. However I just changed them to normal function calls to simplify things.