### PR TITLE
Fix some typos/bugs with float comparison intrinsics

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5430,10 +5430,8 @@ mod c {
         if target_arch == "arm" && target_os != "ios" {
             sources.extend(
                 &[
-                    "arm/aeabi_dcmp.S",
                     "arm/aeabi_div0.c",
                     "arm/aeabi_drsub.c",
-                    "arm/aeabi_fcmp.S",
                     "arm/aeabi_frsub.c",
                     "arm/bswapdi2.S",
                     "arm/bswapsi2.S",

--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -120,7 +120,7 @@ intrinsics! {
         cmp(a, b).to_ge_abi()
     }
 
-    #[arm_aeabi_alias = fcmpun]
+    #[arm_aeabi_alias = __aeabi_fcmpun]
     pub extern "C" fn __unordsf2(a: f32, b: f32) -> i32 {
         unord(a, b) as i32
     }
@@ -149,7 +149,7 @@ intrinsics! {
         cmp(a, b).to_ge_abi()
     }
 
-    #[arm_aeabi_alias = dcmpun]
+    #[arm_aeabi_alias = __aeabi_dcmpun]
     pub extern "C" fn __unorddf2(a: f64, b: f64) -> i32 {
         unord(a, b) as i32
     }
@@ -166,7 +166,50 @@ intrinsics! {
         cmp(a, b).to_le_abi()
     }
 
-    pub extern "C" fn __gtdf2(a: f32, b: f32) -> i32 {
+    pub extern "C" fn __gtdf2(a: f64, b: f64) -> i32 {
         cmp(a, b).to_ge_abi()
+    }
+}
+
+#[cfg(target_arch = "arm")]
+intrinsics! {
+    pub extern "aapcs" fn __aeabi_fcmple(a: f32, b: f32) -> i32 {
+        (__lesf2(a, b) < 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_fcmpge(a: f32, b: f32) -> i32 {
+        (__gesf2(a, b) >= 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_fcmpeq(a: f32, b: f32) -> i32 {
+        (__eqsf2(a, b) == 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_fcmplt(a: f32, b: f32) -> i32 {
+        (__ltsf2(a, b) < 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_fcmpgt(a: f32, b: f32) -> i32 {
+        (__gtsf2(a, b) > 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_dcmple(a: f64, b: f64) -> i32 {
+        (__ledf2(a, b) <= 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_dcmpge(a: f64, b: f64) -> i32 {
+        (__gedf2(a, b) >= 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_dcmpeq(a: f64, b: f64) -> i32 {
+        (__eqdf2(a, b) == 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_dcmplt(a: f64, b: f64) -> i32 {
+        (__ltdf2(a, b) < 0) as i32
+    }
+
+    pub extern "aapcs" fn __aeabi_dcmpgt(a: f64, b: f64) -> i32 {
+        (__gtdf2(a, b) > 0) as i32
     }
 }


### PR DESCRIPTION
* I believe `__gtdf2` erroneously used `f32` instead of `f64`
* Most of these needed `#[arm_aeabi_alias]` to ensure they're correctly called
  through the alias
* Some existing aliases were corrected with the right names