### PR TITLE
Add support for mul[s/d]f3vfp and div[s/d]f3vfp

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ features = ["c"]
 - [x] arm/aeabi_memset.S
 - [x] arm/aeabi_uidivmod.S
 - [x] arm/aeabi_uldivmod.S
-- [ ] arm/divdf3vfp.S
+- [x] arm/divdf3vfp.S
 - [ ] arm/divmodsi4.S (generic version is done)
-- [ ] arm/divsf3vfp.S
+- [x] arm/divsf3vfp.S
 - [ ] arm/divsi3.S (generic version is done)
 - [ ] arm/eqdf2vfp.S
 - [ ] arm/eqsf2vfp.S
@@ -120,8 +120,8 @@ features = ["c"]
 - [ ] arm/ltdf2vfp.S
 - [ ] arm/ltsf2vfp.S
 - [ ] arm/modsi3.S (generic version is done)
-- [ ] arm/muldf3vfp.S
-- [ ] arm/mulsf3vfp.S
+- [x] arm/muldf3vfp.S
+- [x] arm/mulsf3vfp.S
 - [ ] arm/nedf2vfp.S
 - [ ] arm/negdf2vfp.S
 - [ ] arm/negsf2vfp.S

--- a/build.rs
+++ b/build.rs
@@ -4260,6 +4260,11 @@ fn muldf3() {
           target_os = "linux",
           test))]
 use core::mem;
+#[cfg(not(all(target_arch = "arm",
+              not(any(target_env = "gnu", target_env = "musl")),
+              target_os = "linux",
+              test)))]
+use std::mem;
 use compiler_builtins::float::mul::__mulsf3vfp;
 
 fn mk_f32(x: u32) -> f32 {
@@ -4342,6 +4347,11 @@ fn mulsf3vfp() {
           target_os = "linux",
           test))]
 use core::mem;
+#[cfg(not(all(target_arch = "arm",
+              not(any(target_env = "gnu", target_env = "musl")),
+              target_os = "linux",
+              test)))]
+use std::mem;
 use compiler_builtins::float::mul::__muldf3vfp;
 
 fn mk_f64(x: u64) -> f64 {
@@ -4609,6 +4619,11 @@ fn divdf3() {
           target_os = "linux",
           test))]
 use core::mem;
+#[cfg(not(all(target_arch = "arm",
+              not(any(target_env = "gnu", target_env = "musl")),
+              target_os = "linux",
+              test)))]
+use std::mem;
 use compiler_builtins::float::div::__divsf3vfp;
 
 fn mk_f32(x: u32) -> f32 {
@@ -4695,6 +4710,11 @@ fn divsf3vfp() {
           target_os = "linux",
           test))]
 use core::mem;
+#[cfg(not(all(target_arch = "arm",
+              not(any(target_env = "gnu", target_env = "musl")),
+              target_os = "linux",
+              test)))]
+use std::mem;
 use compiler_builtins::float::div::__divdf3vfp;
 
 fn mk_f64(x: u64) -> f64 {

--- a/build.rs
+++ b/build.rs
@@ -5511,8 +5511,6 @@ mod c {
                     &[
                         "arm/adddf3vfp.S",
                         "arm/addsf3vfp.S",
-                        "arm/divdf3vfp.S",
-                        "arm/divsf3vfp.S",
                         "arm/eqdf2vfp.S",
                         "arm/eqsf2vfp.S",
                         "arm/extendsfdf2vfp.S",
@@ -5532,8 +5530,6 @@ mod c {
                         "arm/lesf2vfp.S",
                         "arm/ltdf2vfp.S",
                         "arm/ltsf2vfp.S",
-                        "arm/muldf3vfp.S",
-                        "arm/mulsf3vfp.S",
                         "arm/nedf2vfp.S",
                         "arm/nesf2vfp.S",
                         "arm/restore_vfp_d8_d15_regs.S",

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -454,10 +454,12 @@ intrinsics! {
         div64(a, b)
     }
 
+    #[cfg(target_arch = "arm")]
     pub extern "C" fn __divsf3vfp(a: f32, b: f32) -> f32 {
         a / b
     }
 
+    #[cfg(target_arch = "arm")]
     pub extern "C" fn __divdf3vfp(a: f64, b: f64) -> f64 {
         a / b
     }

--- a/src/float/div.rs
+++ b/src/float/div.rs
@@ -454,4 +454,11 @@ intrinsics! {
         div64(a, b)
     }
 
+    pub extern "C" fn __divsf3vfp(a: f32, b: f32) -> f32 {
+        a / b
+    }
+
+    pub extern "C" fn __divdf3vfp(a: f64, b: f64) -> f64 {
+        a / b
+    }
 }

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -189,10 +189,12 @@ intrinsics! {
         mul(a, b)
     }
 
+    #[cfg(target_arch = "arm")]
     pub extern "C" fn __mulsf3vfp(a: f32, b: f32) -> f32 {
         a * b
     }
 
+    #[cfg(target_arch = "arm")]
     pub extern "C" fn __muldf3vfp(a: f64, b: f64) -> f64 {
         a * b
     }

--- a/src/float/mul.rs
+++ b/src/float/mul.rs
@@ -188,4 +188,12 @@ intrinsics! {
     pub extern "C" fn __muldf3(a: f64, b: f64) -> f64 {
         mul(a, b)
     }
+
+    pub extern "C" fn __mulsf3vfp(a: f32, b: f32) -> f32 {
+        a * b
+    }
+
+    pub extern "C" fn __muldf3vfp(a: f64, b: f64) -> f64 {
+        a * b
+    }
 }

--- a/tests/divdf3vfp.rs
+++ b/tests/divdf3vfp.rs
@@ -1,0 +1,8 @@
+#![feature(compiler_builtins_lib)]
+#![feature(i128_type)]
+#![cfg_attr(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")),
+                 target_os = "linux", test),
+           no_std)]
+
+#[cfg(target_arch = "arm")]
+include!(concat!(env!("OUT_DIR"), "/divdf3vfp.rs"));

--- a/tests/divsf3vfp.rs
+++ b/tests/divsf3vfp.rs
@@ -1,0 +1,8 @@
+#![feature(compiler_builtins_lib)]
+#![feature(i128_type)]
+#![cfg_attr(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")),
+                 target_os = "linux", test),
+           no_std)]
+
+#[cfg(target_arch = "arm")]
+include!(concat!(env!("OUT_DIR"), "/divsf3vfp.rs"));

--- a/tests/muldf3vfp.rs
+++ b/tests/muldf3vfp.rs
@@ -1,0 +1,8 @@
+#![feature(compiler_builtins_lib)]
+#![feature(i128_type)]
+#![cfg_attr(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")),
+                 target_os = "linux", test),
+           no_std)]
+
+#[cfg(target_arch = "arm")]
+include!(concat!(env!("OUT_DIR"), "/muldf3vfp.rs"));

--- a/tests/mulsf3vfp.rs
+++ b/tests/mulsf3vfp.rs
@@ -1,0 +1,8 @@
+#![feature(compiler_builtins_lib)]
+#![feature(i128_type)]
+#![cfg_attr(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")),
+                 target_os = "linux", test),
+           no_std)]
+
+#[cfg(target_arch = "arm")]
+include!(concat!(env!("OUT_DIR"), "/mulsf3vfp.rs"));


### PR DESCRIPTION
Here using `"C"` the compiler will use `"aapcs"` or `"aapcs-vfp"` depending on target configuration.

Of course this translates in a call to `__aeabi_fdiv` / `__aeabi_fmul` on non-HF targets.

On `eabi` targets with +vfpv2/vfpv3 LLVM generate:

```
   vmov	s0, r1
   vmov	s2, r0
   vdiv.f32	s0, s2, s0
   vmov	r0, s0
   bx	lr
```

On `eabihf` targets with +vfpv3-d16/d32/f32 +fp-only-sp LLVM generate:

```
  vdiv.f32	s0, s0, s1
  bx	lr
```

That's exactly what We need for [div/mul][s/d]f3vfp.S