### PR TITLE
Fix __aeabi_fcmple and add test cases

### DIFF
--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -174,7 +174,7 @@ intrinsics! {
 #[cfg(target_arch = "arm")]
 intrinsics! {
     pub extern "aapcs" fn __aeabi_fcmple(a: f32, b: f32) -> i32 {
-        (__lesf2(a, b) < 0) as i32
+        (__lesf2(a, b) <= 0) as i32
     }
 
     pub extern "aapcs" fn __aeabi_fcmpge(a: f32, b: f32) -> i32 {

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -121,6 +121,98 @@ fn main() {
         },
         "compiler_builtins::float::cmp::__lesf2(a, b)");
 
+    if target_arch_arm {
+        gen(|(a, b): (MyF32, MyF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 <= b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_fcmple(a, b)");
+
+        gen(|(a, b): (MyF32, MyF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 >= b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_fcmpge(a, b)");
+
+        gen(|(a, b): (MyF32, MyF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 == b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_fcmpeq(a, b)");
+
+        gen(|(a, b): (MyF32, MyF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 < b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_fcmplt(a, b)");
+
+        gen(|(a, b): (MyF32, MyF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 > b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_fcmpgt(a, b)");
+
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 <= b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_dcmple(a, b)");
+
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 >= b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_dcmpge(a, b)");
+
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 == b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_dcmpeq(a, b)");
+
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 < b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_dcmplt(a, b)");
+
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                let c = (a.0 > b.0) as i32;
+                Some(c)
+            },
+            "compiler_builtins::float::cmp::__aeabi_dcmpgt(a, b)");
+    }
+
     // float/conv.rs
     gen(|a: MyF64| i64(a.0).ok(),
         "compiler_builtins::float::conv::__fixdfdi(a)");


### PR DESCRIPTION
`le` in __aeabi_fcmple means `less or equal`.

I don't know why a test case is missing, so let's add it now.

Of course it can fail because `__aeabi_fcmple` is already in some nightly build, so We can't test it against a trusted implementation. 

