### PR TITLE
Fix issue extending f32::MIN/MAX to f64 and improve testcrate.

### DIFF
--- a/src/float/extend.rs
+++ b/src/float/extend.rs
@@ -41,7 +41,7 @@ fn extend<F: Float, R: Float>(a: F) -> R where
         let abs_dst: R::Int = a_abs.cast();
         let bias_dst: R::Int = exp_bias_delta.cast();
         abs_result = abs_dst.wrapping_shl(sign_bits_delta);
-        abs_result |= bias_dst.wrapping_shl(dst_sign_bits);
+        abs_result += bias_dst.wrapping_shl(dst_sign_bits);
     } else if a_abs >= src_infinity {
         // a is NaN or infinity.
         // Conjure the result by beginning with infinity, then setting the qNaN

--- a/src/float/sub.rs
+++ b/src/float/sub.rs
@@ -1,14 +1,16 @@
 use float::Float;
+use float::add::__addsf3;
+use float::add::__adddf3;
 
 intrinsics! {
     #[arm_aeabi_alias = __aeabi_fsub]
     pub extern "C" fn __subsf3(a: f32, b: f32) -> f32 {
-        a + f32::from_repr(b.repr() ^ f32::SIGN_MASK)
+        __addsf3(a, f32::from_repr(b.repr() ^ f32::SIGN_MASK))
     }
 
     #[arm_aeabi_alias = __aeabi_dsub]
     pub extern "C" fn __subdf3(a: f64, b: f64) -> f64 {
-        a + f64::from_repr(b.repr() ^ f64::SIGN_MASK)
+        __adddf3(a, f64::from_repr(b.repr() ^ f64::SIGN_MASK))
     }
 
     #[cfg(target_arch = "arm")]

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -703,6 +703,9 @@ macro_rules! gen_float {
                 // Special values
                 *rng.choose(&[-0.0,
                               0.0,
+                              ::std::$fty::MIN,
+                              ::std::$fty::MIN_POSITIVE,
+                              ::std::$fty::MAX,
                               ::std::$fty::NAN,
                               ::std::$fty::INFINITY,
                               -::std::$fty::INFINITY])
@@ -754,6 +757,9 @@ macro_rules! gen_large_float {
                 // Special values
                 *rng.choose(&[-0.0,
                               0.0,
+                              ::std::$fty::MIN,
+                              ::std::$fty::MIN_POSITIVE,
+                              ::std::$fty::MAX,
                               ::std::$fty::NAN,
                               ::std::$fty::INFINITY,
                               -::std::$fty::INFINITY])


### PR DESCRIPTION
I was able to trigger an issue extending f32::MAX or f32::MIN to a f64.
Issue was **not** triggered by `testcrate` mainly because f32::MAX/MIN are
not in the list of special values to generate.

This PR fix the issue and improve `testcrate` adding MAX/MIN/MIN_POSITIVE
in the list of special values.