### PR TITLE
Add `ledf2vfp/leds2vfp`, add test cases for  `__unordsf2/__unorddf2` and re-enable thumb* targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,6 @@ matrix:
     - env: TARGET=x86_64-apple-darwin
       os: osx
     - env: TARGET=x86_64-unknown-linux-gnu
-  allow_failures:
-    - env: TARGET=thumbv6m-linux-eabi
-    - env: TARGET=thumbv7em-linux-eabi
-    - env: TARGET=thumbv7em-linux-eabihf
-    - env: TARGET=thumbv7m-linux-eabi
 
 install:
   - case $TARGET in

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ features = ["c"]
 - [x] arm/gesf2vfp.S
 - [x] arm/gtdf2vfp.S
 - [x] arm/gtsf2vfp.S
-- [ ] arm/ledf2vfp.S
-- [ ] arm/lesf2vfp.S
+- [x] arm/ledf2vfp.S
+- [x] arm/lesf2vfp.S
 - [x] arm/ltdf2vfp.S
 - [x] arm/ltsf2vfp.S
 - [ ] arm/modsi3.S (generic version is done)

--- a/build.rs
+++ b/build.rs
@@ -384,8 +384,6 @@ mod c {
                         "arm/floatsisfvfp.S",
                         "arm/floatunssidfvfp.S",
                         "arm/floatunssisfvfp.S",
-                        "arm/ledf2vfp.S",
-                        "arm/lesf2vfp.S",
                         "arm/restore_vfp_d8_d15_regs.S",
                         "arm/save_vfp_d8_d15_regs.S",
                     ],

--- a/src/float/cmp.rs
+++ b/src/float/cmp.rs
@@ -240,6 +240,14 @@ intrinsics! {
         (a < b) as i32
     }
 
+    pub extern "C" fn __lesf2vfp(a: f32, b: f32) -> i32 {
+        (a <= b) as i32
+    }
+
+    pub extern "C" fn __ledf2vfp(a: f64, b: f64) -> i32 {
+        (a <= b) as i32
+    }
+
     pub extern "C" fn __nesf2vfp(a: f32, b: f32) -> i32 {
         (a != b) as i32
     }

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -143,6 +143,18 @@ fn main() {
         },
         "compiler_builtins::float::cmp::__lesf2(a, b)");
 
+    gen(|(a, b): (MyF32, MyF32)| {
+            let c = a.0.is_nan() || b.0.is_nan();
+            Some(c as i32)
+        },
+        "compiler_builtins::float::cmp::__unordsf2(a, b)");
+
+    gen(|(a, b): (MyF64, MyF64)| {
+            let c = a.0.is_nan() || b.0.is_nan();
+            Some(c as i32)
+        },
+        "compiler_builtins::float::cmp::__unorddf2(a, b)");
+
     if target_arch_arm {
         gen(|(a, b): (MyF32, MyF32)| {
                 if a.0.is_nan() || b.0.is_nan() {

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -280,6 +280,20 @@ fn main() {
                 if a.0.is_nan() || b.0.is_nan() {
                     return None;
                 }
+                Some((a.0 <= b.0) as i32)
+            },
+            "compiler_builtins::float::cmp::__lesf2vfp(a, b)");
+        gen(|(a, b): (MyF64, MyF64)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
+                Some((a.0 <= b.0) as i32)
+            },
+            "compiler_builtins::float::cmp::__ledf2vfp(a, b)");
+        gen(|(a, b): (LargeF32, LargeF32)| {
+                if a.0.is_nan() || b.0.is_nan() {
+                    return None;
+                }
                 Some((a.0 != b.0) as i32)
             },
             "compiler_builtins::float::cmp::__nesf2vfp(a, b)");


### PR DESCRIPTION
Just a collection of minor changes:

- Now that `73884ae` is in some nightly release We can add `ledf2vfp/leds2vfp` and so these two functions can be aliased to `aeabi_fcmple/aeabi_dcmple` on soft-float targets.

- Add missing test cases for `__unordsf2/__unorddf2 `

- Remove `allow_failures` for thumb* targets