### PR TITLE
Add __floatdisf and __floatundisf intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ features = ["c"]
 - [x] fixunssfdi.c
 - [x] fixunssfsi.c
 - [x] floatdidf.c
-- [ ] floatdisf.c
+- [x] floatdisf.c
 - [x] floatsidf.c
 - [x] floatsisf.c
 - [x] floatundidf.c
-- [ ] floatundisf.c
+- [x] floatundisf.c
 - [x] floatunsidf.c
 - [x] floatunsisf.c
 - [ ] i386/ashldi3.S

--- a/build.rs
+++ b/build.rs
@@ -4991,8 +4991,6 @@ mod c {
                 "divxc3.c",
                 "extendsfdf2.c",
                 "extendhfsf2.c",
-                "floatdisf.c",
-                "floatundisf.c",
                 "int_util.c",
                 "muldc3.c",
                 "mulsc3.c",

--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -81,6 +81,18 @@ intrinsics! {
     }
 
     #[use_c_shim_if(all(target_arch = "x86", not(target_env = "msvc")))]
+    #[arm_aeabi_alias = __aeabi_l2f]
+    pub extern "C" fn __floatdisf(i: i64) -> f32 {
+        // On x86_64 LLVM will use native instructions for this conversion, we
+        // can just do it directly
+        if cfg!(target_arch = "x86_64") {
+            i as f32
+        } else {
+            int_to_float!(i, i64, f32)
+        }
+    }
+
+    #[use_c_shim_if(all(target_arch = "x86", not(target_env = "msvc")))]
     #[arm_aeabi_alias = __aeabi_l2d]
     pub extern "C" fn __floatdidf(i: i64) -> f64 {
         // On x86_64 LLVM will use native instructions for this conversion, we
@@ -110,6 +122,14 @@ intrinsics! {
     #[arm_aeabi_alias = __aeabi_ui2d]
     pub extern "C" fn __floatunsidf(i: u32) -> f64 {
         int_to_float!(i, u32, f64)
+    }
+
+    #[use_c_shim_if(all(not(target_env = "msvc"),
+                        any(target_arch = "x86",
+                            all(not(windows), target_arch = "x86_64"))))]
+    #[arm_aeabi_alias = __aeabi_ul2f]
+    pub extern "C" fn __floatundisf(i: u64) -> f32 {
+        int_to_float!(i, u64, f32)
     }
 
     #[use_c_shim_if(all(not(target_env = "msvc"),


### PR DESCRIPTION
I created this some months back for personal use - I didn't create a PR then because I suspected the actual solution should be more involved than cargo-culting the existing implementation of `__floatdidf` and `__floatundidf` and changing the type, but @alexcrichton said I should be bold.

Resolves issue #216.