### PR TITLE
use system library on openbsd

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,13 @@ fn main() {
         return;
     }
 
+    // OpenBSD provides compiler_rt by default, use it instead of rebuilding it from source
+    if target.contains("openbsd") {
+        println!("cargo:rustc-link-search=native=/usr/lib");
+        println!("cargo:rustc-link-lib=static=compiler_rt");
+        return;
+    }
+
     // Forcibly enable memory intrinsics on wasm32 as we don't have a libc to
     // provide them.
     if target.contains("wasm32") {


### PR DESCRIPTION
compiler_rt is provided by default on OpenBSD, so use it instead of
rebuilding it from source.