### PR TITLE
expose math symbols on wasm32-unknown-unknown

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "compiler-rt"]
 	path = compiler-rt
 	url = https://github.com/rust-lang/compiler-rt
+[submodule "libm"]
+	path = libm
+	url = https://github.com/japaric/libm

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - env: TARGET=thumbv7em-linux-eabi
     - env: TARGET=thumbv7em-linux-eabihf
     - env: TARGET=thumbv7m-linux-eabi
+    - env: TARGET=wasm32-unknown-unknown
+      install: rustup target add $TARGET
+      script: cargo build --target $TARGET
     - env: TARGET=x86_64-apple-darwin
       os: osx
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub mod int;
 pub mod float;
 
 pub mod mem;
+// only for the wasm32-unknown-unknown target
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod math;
 
 #[cfg(target_arch = "arm")]
 pub mod arm;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,51 @@
+#[allow(dead_code)]
+#[path = "../../libm/src/math/mod.rs"]
+mod libm;
+
+macro_rules! no_mangle {
+    ($(fn $fun:ident($($iid:ident : $ity:ty),+) -> $oty:ty;)+) => {
+        $(
+            #[no_mangle]
+            pub fn $fun($($iid: $ity),+) -> $oty {
+                self::libm::$fun($($iid),+)
+            }
+        )+
+    }
+}
+
+no_mangle! {
+    fn acos(x: f64) -> f64;
+    fn asin(x: f64) -> f64;
+    fn atan(x: f64) -> f64;
+    fn atan2(x: f64, y: f64) -> f64;
+    fn cbrt(x: f64) -> f64;
+    fn cosh(x: f64) -> f64;
+    fn expm1(x: f64) -> f64;
+    fn hypot(x: f64, y: f64) -> f64;
+    fn log1p(x: f64) -> f64;
+    fn sinh(x: f64) -> f64;
+    fn tan(x: f64) -> f64;
+    fn tanh(x: f64) -> f64;
+    fn cos(x: f64) -> f64;
+    fn cosf(x: f32) -> f32;
+    fn exp(x: f64) -> f64;
+    fn expf(x: f32) -> f32;
+    fn log2(x: f64) -> f64;
+    fn log2f(x: f32) -> f32;
+    fn log10(x: f64) -> f64;
+    fn log10f(x: f32) -> f32;
+    fn log(x: f64) -> f64;
+    fn logf(x: f32) -> f32;
+    fn round(x: f64) -> f64;
+    fn roundf(x: f32) -> f32;
+    fn sin(x: f64) -> f64;
+    fn sinf(x: f32) -> f32;
+    fn pow(x: f64, y: f64) -> f64;
+    fn powf(x: f32, y: f32) -> f32;
+    fn exp2(x: f64) -> f64;
+    fn exp2f(x: f32) -> f32;
+    fn fmod(x: f64, y: f64) -> f64;
+    fn fmodf(x: f32, y: f32) -> f32;
+    fn fma(x: f64, y: f64, z: f64) -> f64;
+    fn fmaf(x: f32, y: f32, z: f32) -> f32;
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -4,12 +4,13 @@ mod libm;
 
 macro_rules! no_mangle {
     ($(fn $fun:ident($($iid:ident : $ity:ty),+) -> $oty:ty;)+) => {
-        $(
-            #[no_mangle]
-            pub fn $fun($($iid: $ity),+) -> $oty {
-                self::libm::$fun($($iid),+)
-            }
-        )+
+        intrinsics! {
+            $(
+                pub extern "C" fn $fun($($iid: $ity),+) -> $oty {
+                    self::libm::$fun($($iid),+)
+                }
+            )+
+        }
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[path = "../../libm/src/math/mod.rs"]
+#[path = "../libm/src/math/mod.rs"]
 mod libm;
 
 macro_rules! no_mangle {


### PR DESCRIPTION
r? @alexcrichton 

I think this should do the trick. I wasn't sure how to write a test that checks that the symbols make it to a wasm file -- it seems that the wasm linker is lenient and doesn't throw errors when undefined symbols make it to the final artifact.