### PR TITLE
openbsd: doesn't use `static` as it could result duplicated symbols

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
     // OpenBSD provides compiler_rt by default, use it instead of rebuilding it from source
     if target.contains("openbsd") {
         println!("cargo:rustc-link-search=native=/usr/lib");
-        println!("cargo:rustc-link-lib=static=compiler_rt");
+        println!("cargo:rustc-link-lib=compiler_rt");
         return;
     }
 


### PR DESCRIPTION
I found using `static` here could result in problem for `librsvg` building.

`librsvg` first generates a static library with Rust code, and next mix objects from C code and Rust code to make a dynamic library.

when using `static`, the resulting `rlib` contains:
- all symbols from compiler-builtins Rust code
- all symbols from `libcompiler_rt.a`

and so, duplicated symbols.

It isn't a problem when linking `dylib` or binary: the linker will keep only the first resolved symbol. But the way `librsvg` build makes the linker to see the duplicated symbols.

Without `static`, the generated `rlib` contains:
- all symbols from compiler-builtins Rust code
- only others symbols from `libcompiler_rt.a` (OpenBSD doesn't provide dynamic library for compiler_rt)

I have backported the PR on OpenBSD ports tree and use without problem for the following program/library: rustc/cargo, firefox, ripgrep, exa, librsvg