### PR TITLE
expose fmod{,f} symbols on thumb

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ mod macros;
 pub mod int;
 pub mod float;
 
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"),
+          all(target_arch = "arm", target_os = "none")))]
 pub mod math;
 pub mod mem;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,8 @@ mod macros;
 pub mod int;
 pub mod float;
 
-pub mod mem;
-// only for the wasm32-unknown-unknown target
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod math;
+pub mod mem;
 
 #[cfg(target_arch = "arm")]
 pub mod arm;

--- a/src/math.rs
+++ b/src/math.rs
@@ -14,6 +14,8 @@ macro_rules! no_mangle {
     }
 }
 
+// only for the wasm32-unknown-unknown target
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;
@@ -49,4 +51,13 @@ no_mangle! {
     fn fmodf(x: f32, y: f32) -> f32;
     fn fma(x: f64, y: f64, z: f64) -> f64;
     fn fmaf(x: f32, y: f32, z: f32) -> f32;
+}
+
+// only for the thumb*-none-eabi* targets
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+no_mangle! {
+    // `f64 % f64`
+    fn fmod(x: f64, y: f64) -> f64;
+    // `f32 % f32`
+    fn fmodf(x: f32, y: f32) -> f32;
 }


### PR DESCRIPTION
these symbols are required for the built-in operation `f32 % f32`