### PR TITLE
Implement __mulsi3.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub mod arm;
 #[cfg(all(kernel_user_helpers, target_os = "linux", target_arch = "arm"))]
 pub mod arm_linux;
 
+#[cfg(any(target_arch = "riscv32"))]
+pub mod riscv32;
+
 #[cfg(target_arch = "x86")]
 pub mod x86;
 

--- a/src/riscv32.rs
+++ b/src/riscv32.rs
@@ -1,0 +1,17 @@
+intrinsics! {
+    // Implementation from gcc
+    // https://raw.githubusercontent.com/gcc-mirror/gcc/master/libgcc/config/epiphany/mulsi3.c
+    pub extern "C" fn __mulsi3(mut a: u32, mut b: u32) -> u32 {
+        let mut r: usize = 0;
+
+        while a > 0 {
+            if a & 1 > 0 {
+                r += b;
+            }
+            a >>= 1;
+            b <<= 1;
+        }
+
+        r
+    }
+}


### PR DESCRIPTION
Adds __mulsi3 intrinsic for RISCV target required when no hardware multiplication unit is available.

PR adding riscv support to rust: https://github.com/rust-lang/rust/pull/52787