### PR TITLE
Fix symbol collision caused by `floatdisf`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -267,7 +267,6 @@ mod c {
                 if target_arch == "x86_64" {
                     sources.extend(
                         &[
-                            "x86_64/floatdisf.c",
                             "x86_64/floatdixf.c",
                             "x86_64/floatundidf.S",
                             "x86_64/floatundisf.S",

--- a/build.rs
+++ b/build.rs
@@ -269,7 +269,6 @@ mod c {
                         &[
                             "x86_64/floatdixf.c",
                             "x86_64/floatundidf.S",
-                            "x86_64/floatundisf.S",
                             "x86_64/floatundixf.S",
                         ],
                     );


### PR DESCRIPTION
[PR #234](https://github.com/rust-lang-nursery/compiler-builtins/pull/234) added floatdisf implementation in rust and removed floatdisf.c from build.rs. However the removal is in-complete. In x86_64+!msvc environment, the symbol `floatdisf` would be generated twice. Build failures occured in Redox OS issue [#1195](https://gitlab.redox-os.org/redox-os/redox/issues/1195) and Mesalink travis [log](https://travis-ci.org/mesalock-linux/mesalink/jobs/412928048) at line 738. This patch fixes it by removing floatdisf.c from this environment.

Signed-off-by: Yu Ding <dingelish@gmail.com>