### PR TITLE
Fix __sync_fetch_and_nand_* for pre-v6 ARM

### DIFF
--- a/src/arm_linux.rs
+++ b/src/arm_linux.rs
@@ -125,9 +125,9 @@ atomic_rmw!(__sync_fetch_and_xor_1, u8, |a: u8, b: u8| a ^ b);
 atomic_rmw!(__sync_fetch_and_xor_2, u16, |a: u16, b: u16| a ^ b);
 atomic_rmw!(__sync_fetch_and_xor_4, u32, |a: u32, b: u32| a ^ b);
 
-atomic_rmw!(__sync_fetch_and_nand_1, u8, |a: u8, b: u8| !a & b);
-atomic_rmw!(__sync_fetch_and_nand_2, u16, |a: u16, b: u16| !a & b);
-atomic_rmw!(__sync_fetch_and_nand_4, u32, |a: u32, b: u32| !a & b);
+atomic_rmw!(__sync_fetch_and_nand_1, u8, |a: u8, b: u8| !(a & b));
+atomic_rmw!(__sync_fetch_and_nand_2, u16, |a: u16, b: u16| !(a & b));
+atomic_rmw!(__sync_fetch_and_nand_4, u32, |a: u32, b: u32| !(a & b));
 
 atomic_rmw!(__sync_fetch_and_max_1, i8, |a: i8, b: i8| if a > b { a } else { b });
 atomic_rmw!(__sync_fetch_and_max_2, i16, |a: i16, b: i16| if a > b { a } else { b });


### PR DESCRIPTION
gcc changed semantics for __sync_fetch_and_nand_* in gcc 4.4,
and this was implementing the old semantics:
https://gcc.gnu.org/onlinedocs/gcc-8.2.0/gcc/_005f_005fsync-Builtins.html