### PR TITLE
Rename `panic_implementation` -> `panic_handler`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 cc = { optional = true, version = "1.0" }
 
 [dev-dependencies]
-panic-implementation = { path = 'crates/panic-implementation' }
+panic-handler = { path = 'crates/panic-handler' }
 
 [features]
 default = ["compiler-builtins"]

--- a/crates/panic-handler/Cargo.toml
+++ b/crates/panic-handler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "panic-implementation"
+name = "panic-handler"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 

--- a/crates/panic-handler/src/lib.rs
+++ b/crates/panic-handler/src/lib.rs
@@ -1,11 +1,11 @@
 // Hack of a crate until rust-lang/rust#51647 is fixed
 
-#![feature(no_core, panic_implementation)]
+#![feature(no_core, panic_handler)]
 #![no_core]
 
 extern crate core;
 
-#[panic_implementation]
+#[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}
 }

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -11,11 +11,11 @@
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(allocator_api)]
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![cfg_attr(windows, feature(panic_unwind))]
 #![no_std]
 
-extern crate panic_implementation;
+extern crate panic_handler;
 
 #[cfg(not(thumb))]
 #[link(name = "c")]


### PR DESCRIPTION

Recently `panic_implementation` has been deprecated or better renamed in `panic_handler`. Rename it also here to avoid annoying warning messages.