### PR TITLE
Attempt to fix TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=armv7-unknown-linux-gnueabihf
     - env: TARGET=i586-unknown-linux-gnu
-    - env: TARGET=i686-apple-darwin
+    - env: TARGET=i686-apple-darwin DEBUG_LTO_BUILD_DOESNT_WORK=1
       os: osx
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=mips-unknown-linux-gnu
@@ -28,7 +28,7 @@ matrix:
     - env: TARGET=wasm32-unknown-unknown
       install: rustup target add $TARGET
       script: cargo build --target $TARGET
-    - env: TARGET=x86_64-apple-darwin
+    - env: TARGET=x86_64-apple-darwin DEBUG_LTO_BUILD_DOESNT_WORK=1
       os: osx
     - env: TARGET=x86_64-unknown-linux-gnu
   allow_failures:

--- a/crates/panic-handler/src/lib.rs
+++ b/crates/panic-handler/src/lib.rs
@@ -1,6 +1,6 @@
 // Hack of a crate until rust-lang/rust#51647 is fixed
 
-#![feature(no_core, panic_handler)]
+#![feature(no_core)]
 #![no_core]
 
 extern crate core;

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -11,7 +11,6 @@
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(allocator_api)]
-#![feature(panic_handler)]
 #![cfg_attr(windows, feature(panic_unwind))]
 #![no_std]
 


### PR DESCRIPTION
- Set `DEBUG_LTO_BUILD_DOESNT_WORK` for `i686-apple-darwin` and `x86_64-apple-darwin` to avoid the undefined reference problem with debug-assertions+lto

- Remove `#[panic_handler]` attribute since this feature is now stable