### PR TITLE
Add SGX target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,9 +17,9 @@ fn main() {
         return;
     }
 
-    // Forcibly enable memory intrinsics on wasm32 as we don't have a libc to
+    // Forcibly enable memory intrinsics on wasm32 & SGX as we don't have a libc to
     // provide them.
-    if target.contains("wasm32") {
+    if target.contains("wasm32") || target.contains("sgx") {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@ pub mod int;
 pub mod float;
 
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"),
-          all(target_arch = "arm", target_os = "none")))]
+          all(target_arch = "arm", target_os = "none"),
+          target_env = "sgx"))]
 pub mod math;
 pub mod mem;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -15,7 +15,7 @@ macro_rules! no_mangle {
 }
 
 // only for the wasm32-unknown-unknown target
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), target_env = "sgx"))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;

--- a/src/math.rs
+++ b/src/math.rs
@@ -51,6 +51,19 @@ no_mangle! {
     fn fmodf(x: f32, y: f32) -> f32;
     fn fma(x: f64, y: f64, z: f64) -> f64;
     fn fmaf(x: f32, y: f32, z: f32) -> f32;
+    fn acosf(n: f32) -> f32;
+    fn asinf(n: f32) -> f32;
+    fn atan2f(a: f32, b: f32) -> f32;
+    fn atanf(n: f32) -> f32;
+    fn cbrtf(n: f32) -> f32;
+    fn coshf(n: f32) -> f32;
+    fn expm1f(n: f32) -> f32;
+    fn fdimf(a: f32, b: f32) -> f32;
+    fn hypotf(x: f32, y: f32) -> f32;
+    fn log1pf(n: f32) -> f32;
+    fn sinhf(n: f32) -> f32;
+    fn tanf(n: f32) -> f32;
+    fn tanhf(n: f32) -> f32;
 }
 
 // only for the thumb*-none-eabi* targets


### PR DESCRIPTION
As suggested by @alexcrichton in https://github.com/rust-lang/rust/pull/56066#discussion_r235078452 and https://github.com/rust-lang/rust/pull/56066#discussion_r235086404.

This also adds f32 versions of acosf, asinf, atan2f, atanf, cbrtf, coshf, expm1f, fdimf, hypotf, log1pf, sinhf, tanf, tanhf to the wasm target. These have recently been implemented. With this change, the conversion functions in https://github.com/rust-lang/rust/blob/b74215a/src/libstd/sys/wasm/cmath.rs#L11-L75 are obsolete and can be swapped out for their f32 versions. I have included that change in my SGX PR for std which updates the compiler-builtins submodule.