### PR TITLE
Prepare for publication to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ version = "0.1.0"
 [lib]
 test = false
 
+[dependencies]
+# For more information on this dependency see rust-lang/rust's
+# `src/tools/rustc-std-workspace` folder
+core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
+
 [build-dependencies]
 cc = { optional = true, version = "1.0" }
 
@@ -31,6 +36,9 @@ mangled-names = []
 
 # Don't generate lang items for i128 intrisnics and such
 no-lang-items = []
+
+# Only used in the compiler's build system
+rustc-dep-of-std = ['c', 'compiler-builtins', 'core']
 
 [[example]]
 name = "intrinsics"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,9 @@ required-features = ["c", "compiler-builtins"]
 
 [workspace]
 members = ["testcrate"]
+
+[profile.release]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -64,18 +64,7 @@ case $1 in
         ;;
 esac
 
-case "$TRAVIS_OS_NAME" in
-    osx)
-        # NOTE OSx's nm doesn't accept the `--defined-only` or provide an equivalent.
-        # Use GNU nm instead
-        NM=gnm
-        brew update
-        brew install binutils
-        ;;
-    *)
-        NM=nm
-        ;;
-esac
+NM=nm
 
 if [ -d /target ]; then
     path=/target/${1}/debug/deps/libcompiler_builtins-*.rlib

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -11,7 +11,6 @@
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(allocator_api)]
-#![cfg_attr(windows, feature(panic_unwind))]
 #![no_std]
 
 extern crate panic_handler;


### PR DESCRIPTION
This commit prepares to publish the compiler-builtins crate to crates.io
in order for the standard library to directly depend on it from
crates.io in rust-lang/rust#56092