### PR TITLE
expose ceil, floor and trunc on sgx-target

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -66,6 +66,16 @@ no_mangle! {
     fn tanhf(n: f32) -> f32;
 }
 
+#[cfg(target_env = "sgx")]
+no_mangle! {
+    fn ceil(x: f64) -> f64;
+    fn ceilf(x: f32) -> f32;
+    fn floor(x: f64) -> f64;
+    fn floorf(x: f32) -> f32;
+    fn trunc(x: f64) -> f64;
+    fn truncf(x: f32) -> f32;
+}
+
 // only for the thumb*-none-eabi* targets
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 no_mangle! {


### PR DESCRIPTION
The compiler intrinsics will link to these.

Do I need to do this for wasm32 as well? I didn't get any errors when I tried it on the playground. But I am not sure if that suffices.