### PR TITLE
Fix SGX target_env collision

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
 
     // Forcibly enable memory intrinsics on wasm32 & SGX as we don't have a libc to
     // provide them.
-    if target.contains("wasm32") || target.contains("sgx") {
+    if target.contains("wasm32") || (target.contains("sgx") && target.contains("fortanix")) {
         println!("cargo:rustc-cfg=feature=\"mem\"");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(abi_unadjusted)]
 #![feature(linkage)]
 #![feature(lang_items)]
+#![feature(cfg_target_vendor)]
 #![allow(unused_features)]
 #![no_builtins]
 #![cfg_attr(feature = "compiler-builtins", feature(staged_api))]
@@ -49,7 +50,7 @@ pub mod float;
 
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"),
           all(target_arch = "arm", target_os = "none"),
-          target_env = "sgx"))]
+          all(target_vendor = "fortanix", target_env = "sgx")))]
 pub mod math;
 pub mod mem;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -15,7 +15,8 @@ macro_rules! no_mangle {
 }
 
 // only for the wasm32-unknown-unknown target
-#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), target_env = "sgx"))]
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"),
+          all(target_vendor = "fortanix", target_env = "sgx")))]
 no_mangle! {
     fn acos(x: f64) -> f64;
     fn asin(x: f64) -> f64;
@@ -66,7 +67,7 @@ no_mangle! {
     fn tanhf(n: f32) -> f32;
 }
 
-#[cfg(target_env = "sgx")]
+#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 no_mangle! {
     fn ceil(x: f64) -> f64;
     fn ceilf(x: f32) -> f32;


### PR DESCRIPTION
As discussed in issue [57231](https://github.com/rust-lang/rust/issues/57231) and a merged PR [57243](https://github.com/rust-lang/rust/pull/57243), all `target_env = "sgx"` should be accompanied with a target_vendor check. This commit adds these checks to compiler-builtins.

Signed-off-by: Yu Ding <dingelish@gmail.com>