### PR TITLE
Don't build compiler-rt for NVPTX

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,8 +36,8 @@ fn main() {
     // build anything and we rely on the upstream implementation of compiler-rt
     // functions
     if !cfg!(feature = "mangled-names") && cfg!(feature = "c") {
-        // no C compiler for wasm
-        if !target.contains("wasm32") {
+        // Don't use C compiler for bitcode-only wasm and nvptx
+        if !target.contains("wasm32") && !target.contains("nvptx") {
             #[cfg(feature = "c")]
             c::compile(&llvm_target);
             println!("cargo:rustc-cfg=use_c");


### PR DESCRIPTION
The change is needed to avoid mixed bitcode and machine code since NVPTX Rust target often uses [`obj_is_bitcode: true`](https://github.com/denzp/rust-ptx-linker/blob/master/targets/nvptx64-nvidia-cuda.json#L17) flag. 