### PR TITLE
Version Bump for count leading zeros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "compiler_builtins"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/compiler-builtins"


### PR DESCRIPTION
We've added a new function. It's my understanding that, given how the Rust community uses SemVer, and since we're at a 0.x.y version at the moment, a new function means we bump the `y` version number.