### PR TITLE
Fix compilation on new nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 #![feature(abi_unadjusted)]
 #![feature(linkage)]
 #![feature(lang_items)]
-#![feature(cfg_target_vendor)]
 #![allow(unused_features)]
 #![no_builtins]
 #![cfg_attr(feature = "compiler-builtins", feature(staged_api))]


### PR DESCRIPTION
Compilation on rustc 1.33.0-nightly (c76f3c374 2019-01-18) failed with
```
error: the feature `cfg_target_vendor` has been stable since 1.33.0 and no longer requires an attribute to enable
  --> src/lib.rs:19:12
   |
19 | #![feature(cfg_target_vendor)]
   |            ^^^^^^^^^^^^^^^^^
   |
```

Removed the attribute to make it compile.