### PR TITLE
Fix compilation errors for Armv8-M Baseline and Mainline with FPU

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,10 +49,11 @@ fn main() {
         println!("cargo:rustc-cfg=thumb")
     }
 
-    // compiler-rt `cfg`s away some intrinsics for thumbv6m because that target doesn't have full
-    // THUMBv2 support. We have to cfg our code accordingly.
-    if llvm_target[0] == "thumbv6m" {
-        println!("cargo:rustc-cfg=thumbv6m")
+    // compiler-rt `cfg`s away some intrinsics for thumbv6m and thumbv8m.base because
+    // these targets do not have full Thumb-2 support but only original Thumb-1.
+    // We have to cfg our code accordingly.
+    if llvm_target[0] == "thumbv6m" || llvm_target[0] == "thumbv8m.base" {
+        println!("cargo:rustc-cfg=thumb_1")
     }
 
     // Only emit the ARM Linux atomic emulation on pre-ARMv6 architectures.
@@ -407,7 +408,7 @@ mod c {
         }
 
         // Remove the assembly implementations that won't compile for the target
-        if llvm_target[0] == "thumbv6m" {
+        if llvm_target[0] == "thumbv6m" || llvm_target[0] == "thumbv8m.base" {
             sources.remove(
                 &[
                     "clzdi2",

--- a/build.rs
+++ b/build.rs
@@ -360,24 +360,36 @@ mod c {
         }
 
         if llvm_target.last().unwrap().ends_with("eabihf") {
-            if !llvm_target[0].starts_with("thumbv7em") {
+            if !llvm_target[0].starts_with("thumbv7em") &&
+               !llvm_target[0].starts_with("thumbv8m.main") {
+                // The FPU option chosen for these architectures in cc-rs, ie:
+                //     -mfpu=fpv4-sp-d16 for thumbv7em
+                //     -mfpu=fpv5-sp-d16 for thumbv8m.main
+                // do not support double precision floating points conversions so the files
+                // that include such instructions are not included for these targets.
                 sources.extend(
                     &[
                         "arm/fixdfsivfp.S",
-                        "arm/fixsfsivfp.S",
                         "arm/fixunsdfsivfp.S",
-                        "arm/fixunssfsivfp.S",
                         "arm/floatsidfvfp.S",
-                        "arm/floatsisfvfp.S",
                         "arm/floatunssidfvfp.S",
-                        "arm/floatunssisfvfp.S",
-                        "arm/restore_vfp_d8_d15_regs.S",
-                        "arm/save_vfp_d8_d15_regs.S",
                     ],
                 );
             }
 
-            sources.extend(&["arm/negdf2vfp.S", "arm/negsf2vfp.S"]);
+            sources.extend(
+                &[
+                    "arm/fixsfsivfp.S",
+                    "arm/fixunssfsivfp.S",
+                    "arm/floatsisfvfp.S",
+                    "arm/floatunssisfvfp.S",
+                    "arm/floatunssisfvfp.S",
+                    "arm/restore_vfp_d8_d15_regs.S",
+                    "arm/save_vfp_d8_d15_regs.S",
+                    "arm/negdf2vfp.S",
+                    "arm/negsf2vfp.S",
+                ]
+            );
 
         }
 

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -19,9 +19,6 @@ extern crate panic_handler;
 #[link(name = "c")]
 extern {}
 
-// NOTE cfg(not(thumbv6m)) means that the operation is not supported on ARMv6-M at all. Not even
-// compiler-rt provides a C/assembly implementation.
-
 // Every function in this module maps will be lowered to an intrinsic by LLVM, if the platform
 // doesn't have native support for the operation used in the function. ARM has a naming convention
 // convention for its intrinsics that's different from other architectures; that's why some function
@@ -39,14 +36,8 @@ mod intrinsics {
     }
 
     // fixdfdi
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_d2l(x: f64) -> i64 {
         x as i64
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_d2l(_: f64) -> i64 {
-        0
     }
 
     // fixunsdfsi
@@ -55,14 +46,8 @@ mod intrinsics {
     }
 
     // fixunsdfdi
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_d2ulz(x: f64) -> u64 {
         x as u64
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_d2ulz(_: f64) -> u64 {
-        0
     }
 
     // adddf3
@@ -71,36 +56,18 @@ mod intrinsics {
     }
 
     // eqdf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_dcmpeq(a: f64, b: f64) -> bool {
         a == b
     }
 
-    #[cfg(thumbv6m)]
-    pub fn aeabi_dcmpeq(_: f64, _: f64) -> bool {
-        true
-    }
-
     // gtdf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_dcmpgt(a: f64, b: f64) -> bool {
         a > b
     }
 
-    #[cfg(thumbv6m)]
-    pub fn aeabi_dcmpgt(_: f64, _: f64) -> bool {
-        true
-    }
-
     // ltdf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_dcmplt(a: f64, b: f64) -> bool {
         a < b
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_dcmplt(_: f64, _: f64) -> bool {
-        true
     }
 
     // divdf3
@@ -129,14 +96,8 @@ mod intrinsics {
     }
 
     // fixsfdi
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_f2lz(x: f32) -> i64 {
         x as i64
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_f2lz(_: f32) -> i64 {
-        0
     }
 
     // fixunssfsi
@@ -145,14 +106,8 @@ mod intrinsics {
     }
 
     // fixunssfdi
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_f2ulz(x: f32) -> u64 {
         x as u64
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_f2ulz(_: f32) -> u64 {
-        0
     }
 
     // addsf3
@@ -161,36 +116,18 @@ mod intrinsics {
     }
 
     // eqsf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_fcmpeq(a: f32, b: f32) -> bool {
         a == b
     }
 
-    #[cfg(thumbv6m)]
-    pub fn aeabi_fcmpeq(_: f32, _: f32) -> bool {
-        true
-    }
-
     // gtsf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_fcmpgt(a: f32, b: f32) -> bool {
         a > b
     }
 
-    #[cfg(thumbv6m)]
-    pub fn aeabi_fcmpgt(_: f32, _: f32) -> bool {
-        true
-    }
-
     // ltsf2
-    #[cfg(not(thumbv6m))]
     pub fn aeabi_fcmplt(a: f32, b: f32) -> bool {
         a < b
-    }
-
-    #[cfg(thumbv6m)]
-    pub fn aeabi_fcmplt(_: f32, _: f32) -> bool {
-        true
     }
 
     // divsf3

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -74,8 +74,8 @@ intrinsics! {
 
     #[use_c_shim_if(all(target_arch = "arm",
                     not(target_os = "ios"),
-                    not(target_env = "msvc")),
-                    not(thumbv6m))]
+                    not(target_env = "msvc"),
+                    not(thumb_1)))]
     pub extern "C" fn __modsi3(a: i32, b: i32) -> i32 {
         a.mod_(b)
     }
@@ -91,7 +91,7 @@ intrinsics! {
     }
 
     #[use_c_shim_if(all(target_arch = "arm", not(target_env = "msvc"),
-                    not(target_os = "ios"), not(thumbv6m)))]
+                    not(target_os = "ios"), not(thumb_1)))]
     pub extern "C" fn __divmodsi4(a: i32, b: i32, rem: &mut i32) -> i32 {
         a.divmod(b, rem, |a, b| __divsi3(a, b))
     }

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -212,7 +212,7 @@ intrinsics! {
     #[use_c_shim_if(all(target_arch = "arm",
                         not(target_os = "ios"),
                         not(target_env = "msvc"),
-                        not(thumbv6m)))]
+                        not(thumb_1)))]
     /// Returns `n % d`
     pub extern "C" fn __umodsi3(n: u32, d: u32) -> u32 {
         let q = __udivsi3(n, d);
@@ -222,7 +222,7 @@ intrinsics! {
     #[use_c_shim_if(all(target_arch = "arm",
                         not(target_os = "ios"),
                         not(target_env = "msvc"),
-                        not(thumbv6m)))]
+                        not(thumb_1)))]
     /// Returns `n / d` and sets `*rem = n % d`
     pub extern "C" fn __udivmodsi4(n: u32, d: u32, rem: Option<&mut u32>) -> u32 {
         let q = __udivsi3(n, d);


### PR DESCRIPTION
The larger goal of this pull request is to add `thumbv8m.base-none-eabi` and `thumbv8m.main-none-eabihf` targets to the Rust CI so that the artefacts are available via `rustup`
This pull request specifically fixes the compilation errors encountered when compiling for those targets.

On the way, I added some modifications, not strictly related with those goals and that need to be checked:

* removed from exclusion some Arm assembly files for the FPU targets. I tried to assemble those files independantly with `arm-none-eabi-gcc` with the same options used by `cc-rs` and it was working correctly. Maybe I am missing something on why are these files excluded?
* removed the `cfg(not(thumbv6m))` from the intrinsics example as the "real" functions were compiling fine for `thumbv6m` (and then also `thumbv8m.base`)? I suppose that the intrinsics were implemented for those targets after the `cfg` was made. I suppose then that #75 should be closed? Again, maybe I am missing something.

I was not sure how to test it so I compiled the intrinsics example for the Arm targets:
```
cargo build --example intrinsics --features="c compiler-builtins" --target thumbv6m-none-eabi
cargo build --example intrinsics --features="c compiler-builtins" --target thumbv6m-none-eabi
cargo build --example intrinsics --features="c compiler-builtins" --target thumbv7m-none-eabi
cargo build --example intrinsics --features="c compiler-builtins" --target thumbv7em-none-eabi
cargo build --example intrinsics --features="c compiler-builtins" --target thumbv7em-none-eabihf 
```

Also I patched the Rust compiler with my local modified version of `compiler-builtins` and produced the distribution artefacts, successfully, for all the Arm targets again:
```
./x.py dist --target thumbv6m-none-eabi
./x.py dist --target thumbv7m-none-eabi
./x.py dist --target thumbv7em-none-eabihf
./x.py dist --target thumbv7em-none-eabi
./x.py dist --target thumbv8m.main-none-eabi
./x.py dist --target thumbv8m.main-none-eabihf
./x.py dist --target thumbv8m.base-none-eabi
```