### PR TITLE
Include `ldexp*` intrinsics on the wasm target

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -71,6 +71,8 @@ no_mangle! {
     fn sinhf(n: f32) -> f32;
     fn tanf(n: f32) -> f32;
     fn tanhf(n: f32) -> f32;
+    fn ldexp(f: f64, n: i32) -> f64;
+    fn ldexpf(f: f32, n: i32) -> f32;
 }
 
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]


### PR DESCRIPTION
Looks like LLVM optimizes programs like:

    fn foo(a: u8) -> f32 {
        2.0f32.powf(a as f32)
    }

to actually invoking `ldexpf`, so let's be sure to include bindings so
there's not undefined symbols.