### PR TITLE
Revert "Use the Rust implementation of udivsi3 on ARM"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -289,6 +289,7 @@ mod c {
                     "arm/clzdi2.S",
                     "arm/clzsi2.S",
                     "arm/divmodsi4.S",
+                    "arm/divsi3.S",
                     "arm/modsi3.S",
                     "arm/switch16.S",
                     "arm/switch32.S",
@@ -296,20 +297,8 @@ mod c {
                     "arm/switchu8.S",
                     "arm/sync_synchronize.S",
                     "arm/udivmodsi4.S",
+                    "arm/udivsi3.S",
                     "arm/umodsi3.S",
-
-                    // Exclude these two files for now even though we haven't
-                    // translated their implementation into Rust yet (#173).
-                    // They appear... buggy? The `udivsi3` implementation was
-                    // the one that seemed buggy, but the `divsi3` file
-                    // references a symbol from `udivsi3` so we compile them
-                    // both with the Rust versions.
-                    //
-                    // Note that if these are added back they should be removed
-                    // from thumbv6m below.
-                    //
-                    // "arm/divsi3.S",
-                    // "arm/udivsi3.S",
                 ],
             );
 
@@ -427,12 +416,14 @@ mod c {
                     "clzdi2",
                     "clzsi2",
                     "divmodsi4",
+                    "divsi3",
                     "modsi3",
                     "switch16",
                     "switch32",
                     "switch8",
                     "switchu8",
                     "udivmodsi4",
+                    "udivsi3",
                     "umodsi3",
                 ],
             );

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -24,6 +24,7 @@ run() {
            -v `pwd`:/checkout:ro \
            -v `rustc --print sysroot`:/rust:ro \
            -w /checkout \
+           --init \
            $target \
            sh -c "HOME=/tmp PATH=\$PATH:/rust/bin ci/run.sh $target"
 }

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -57,6 +57,7 @@ impl Divmod for i32 {}
 impl Divmod for i64 {}
 
 intrinsics! {
+    #[use_c_shim_if(all(target_arch = "arm", not(target_os = "ios"), not(thumbv6m)))]
     #[arm_aeabi_alias = __aeabi_idiv]
     pub extern "C" fn __divsi3(a: i32, b: i32) -> i32 {
         a.div(b)

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -152,6 +152,9 @@ macro_rules! udivmod_inner {
 }
 
 intrinsics! {
+    #[use_c_shim_if(all(target_arch = "arm",
+                        not(target_os = "ios"),
+                        not(thumbv6m)))]
     #[arm_aeabi_alias = __aeabi_uidiv]
     /// Returns `n / d`
     pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {


### PR DESCRIPTION
This reverts commit 681aaa914dea7cae8252c33023604ce6c91808bd.

Closes #173