### PR TITLE
Fix duplicate symbol __clzsi2

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -42,6 +42,10 @@ else
     $run --release
     $run --features c
     $run --features c --release
+    cargo build --target $1
+    cargo build --target $1 --release
+    cargo build --target $1 --features c
+    cargo build --target $1 --release --features c
 fi
 
 PREFIX=$(echo $1 | sed -e 's/unknown-//')-
@@ -68,6 +72,10 @@ fi
 # Look out for duplicated symbols when we include the compiler-rt (C) implementation
 for rlib in $(echo $path); do
     set +x
+    echo "================================================================"
+    echo checking $rlib for duplicate symbols
+    echo "================================================================"
+
     stdout=$($PREFIX$NM -g --defined-only $rlib 2>&1)
 
     # NOTE On i586, It's normal that the get_pc_thunk symbol appears several
@@ -86,6 +94,7 @@ for rlib in $(echo $path); do
     if test $? = 0; then
         exit 1
     fi
+
     set -ex
 done
 

--- a/src/float/conv.rs
+++ b/src/float/conv.rs
@@ -83,6 +83,7 @@ intrinsics! {
     #[use_c_shim_if(any(
         all(target_arch = "x86", not(target_env = "msvc")),
         all(target_arch = "x86_64", not(windows)),
+        all(target_arch = "x86_64", target_env = "msvc"),
     ))]
     #[arm_aeabi_alias = __aeabi_l2f]
     pub extern "C" fn __floatdisf(i: i64) -> f32 {

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -302,6 +302,7 @@ impl_wide_int!(u32, u64, 32);
 impl_wide_int!(u64, u128, 64);
 
 intrinsics! {
+    #[use_c_shim_if(/* always if C compilation is enabled */)]
     #[cfg(any(
         target_pointer_width = "16",
         target_pointer_width = "32",
@@ -310,7 +311,7 @@ intrinsics! {
     pub extern "C" fn __clzsi2(x: usize) -> usize {
         // TODO: const this? Would require const-if
         // Note(Lokathor): the `intrinsics!` macro can't process mut inputs
-        let mut x = x; 
+        let mut x = x;
         let mut y: usize;
         let mut n: usize = {
             #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
Looks like our tests weren't quite testing compiler-builtins when it was
compiled with unmangled symbols, so update the tests to catch this and
then fix the compilation of the `__clzsi2` intrinsic to use the C
version if it's compiled.