### PR TITLE
don't force-on c feature when working in rustc workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ mangled-names = []
 no-lang-items = []
 
 # Only used in the compiler's build system
-rustc-dep-of-std = ['c', 'compiler-builtins', 'core']
+rustc-dep-of-std = ['compiler-builtins', 'core']
 
 [[example]]
 name = "intrinsics"


### PR DESCRIPTION
libstd turns on `c` in [it's `Cargo.toml`](https://github.com/rust-lang/rust/blob/80e7cde2238e837a9d6a240af9a3253f469bb2cf/src/libstd/Cargo.toml#L52). That should be enough. Is there a way to verify this?

Fixes https://github.com/rust-lang-nursery/compiler-builtins/issues/288