### PR TITLE
Don't compile C code on riscv targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,8 +37,15 @@ fn main() {
     // build anything and we rely on the upstream implementation of compiler-rt
     // functions
     if !cfg!(feature = "mangled-names") && cfg!(feature = "c") {
-        // Don't use C compiler for bitcode-only wasm and nvptx
-        if !target.contains("wasm32") && !target.contains("nvptx") {
+        // Don't use a C compiler for these targets:
+        //
+        // * wasm32 - clang 8 for wasm is somewhat hard to come by and it's
+        //   unlikely that the C is really that much better than our own Rust.
+        // * nvptx - everything is bitcode, not compatible with mixed C/Rust
+        // * riscv - the rust-lang/rust distribution container doesn't have a C
+        //   compiler nor is cc-rs ready for compilation to riscv (at this
+        //   time). This can probably be removed in the future
+        if !target.contains("wasm32") && !target.contains("nvptx") && !target.starts_with("riscv") {
             #[cfg(feature = "c")]
             c::compile(&llvm_target);
             println!("cargo:rustc-cfg=use_c");


### PR DESCRIPTION
This fixes a longstanding bug in compiler-builtins where C code was
compiled for the riscv targets but when distributed in rust-lang/rust
all the C code was actually compiled for x86_64 since there is no
configured C compiler for riscv. This was exposed by #286 by accident
but the underlying cause was somewhat unrelated.

For now we forcibly disable C code for riscv targets, and when the C
compiler story is sorted out in rust-lang/rust and with `cc-rs` we can
reenable. For now just use all the Rust definitions.

cc rust-lang/rust#60747