### PR TITLE
Remove `compiler-rt` submodule from this repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "compiler-rt"]
-	path = compiler-rt
-	url = https://github.com/rust-lang/compiler-rt
 [submodule "libm"]
 	path = libm
 	url = https://github.com/rust-lang-nursery/libm

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -4,13 +4,15 @@ steps:
 
   - template: azure-install-rust.yml
 
-  - script: rustup component add rust-src
-    displayName: Install Rust sources
-    condition: eq( variables['XARGO'], '1' )
-
   - bash: rustup target add $TARGET
     displayName: Install Rust target
-    condition: ne( variables['XARGO'], '1' )
+
+  - bash: |
+      set -e
+      curl -L https://github.com/rust-lang/llvm-project/archive/rustc/8.0-2019-03-18.tar.gz | \
+        tar xzf - --strip-components 1 llvm-project-rustc-8.0-2019-03-18/compiler-rt
+      echo '##vso[task.setvariable variable=RUST_COMPILER_RT_ROOT]./compiler-rt'
+    displayName: "Download compiler-rt reference sources"
 
   - bash: ./ci/run.sh $TARGET
     condition: ne( variables['Agent.OS'], 'Linux' )

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -18,6 +18,7 @@ run() {
            --user $(id -u):$(id -g) \
            -e CARGO_HOME=/cargo \
            -e CARGO_TARGET_DIR=/target \
+           -e RUST_COMPILER_RT_ROOT \
            -v $HOME/.cargo:/cargo \
            -v `pwd`/target:/target \
            -v `pwd`:/checkout:ro \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,6 +1,5 @@
 set -ex
 
-export CARGO_INCREMENTAL=0
 cargo=cargo
 
 # Test our implementation


### PR DESCRIPTION
This commit removes the `compiler-rt` submodule from this repository.
The goal here is to align the `compiler-rt` used for compiling C
intrinsics with the upstream rust-lang/rust's usage of `llvm-project`.
Currently we have both an `llvm-project` repository as well as
`compiler-rt`, but they can naturally get out of sync and it's just one
more submodule to manage.

The thinking here is that the feature `c` for this crate, when
activated, will require the user to configure where the source code for
`compiler-rt` is present. This places the onus on the builder of
`compiler-builtins` to check-out and arrange for the appropriate
`compiler-rt` source code to be placed somewhere. For rust-lang/rust
this is already done with the `llvm-project` submodule, and we can
arrange for it to happen on this crate's CI anyway.

For users of this crate this is a bit of a bummer, but `c` is disabled
by default anyway and it seems unlikely that `c` is explicitly opted in
to all that much. (given the purpose of this crate)

This should allow us to archive the `compiler-rt` repository and simply
use `llvm-project` in the rust-lang/rust repository.