### PR TITLE
Bump to 0.1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "compiler_builtins"
-version = "0.1.15"
+version = "0.1.16"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/compiler-builtins"


### PR DESCRIPTION
We need to update the crate version to use the new min/max functions in rustc.