### PR TITLE
Replace {u,i}128_* lang items with __rust_{u,i}128_* unmangled functions

### DIFF
--- a/src/int/addsub.rs
+++ b/src/int/addsub.rs
@@ -90,44 +90,43 @@ where
 impl Subo for i128 {}
 impl Subo for u128 {}
 
-u128_lang_items! {
-    #[lang = "i128_add"]
-    pub fn rust_i128_add(a: i128, b: i128) -> i128 {
-        rust_u128_add(a as _, b as _) as _
+intrinsics! {
+    pub extern "C" fn __rust_i128_add(a: i128, b: i128) -> i128 {
+        __rust_u128_add(a as _, b as _) as _
     }
-    #[lang = "i128_addo"]
-    pub fn rust_i128_addo(a: i128, b: i128) -> (i128, bool) {
-        let mut oflow = 0;
-        let r = a.addo(b, &mut oflow);
-        (r, oflow != 0)
-    }
-    #[lang = "u128_add"]
-    pub fn rust_u128_add(a: u128, b: u128) -> u128 {
-        a.add(b)
-    }
-    #[lang = "u128_addo"]
-    pub fn rust_u128_addo(a: u128, b: u128) -> (u128, bool) {
+
+    pub extern "C" fn __rust_i128_addo(a: i128, b: i128) -> (i128, bool) {
         let mut oflow = 0;
         let r = a.addo(b, &mut oflow);
         (r, oflow != 0)
     }
 
-    #[lang = "i128_sub"]
-    pub fn rust_i128_sub(a: i128, b: i128) -> i128 {
-        rust_u128_sub(a as _, b as _) as _
+    pub extern "C" fn __rust_u128_add(a: u128, b: u128) -> u128 {
+        a.add(b)
     }
-    #[lang = "i128_subo"]
-    pub fn rust_i128_subo(a: i128, b: i128) -> (i128, bool) {
+
+    pub extern "C" fn __rust_u128_addo(a: u128, b: u128) -> (u128, bool) {
+        let mut oflow = 0;
+        let r = a.addo(b, &mut oflow);
+        (r, oflow != 0)
+    }
+
+
+    pub extern "C" fn __rust_i128_sub(a: i128, b: i128) -> i128 {
+        __rust_u128_sub(a as _, b as _) as _
+    }
+
+    pub extern "C" fn __rust_i128_subo(a: i128, b: i128) -> (i128, bool) {
         let mut oflow = 0;
         let r = a.subo(b, &mut oflow);
         (r, oflow != 0)
     }
-    #[lang = "u128_sub"]
-    pub fn rust_u128_sub(a: u128, b: u128) -> u128 {
+
+    pub extern "C" fn __rust_u128_sub(a: u128, b: u128) -> u128 {
         a.sub(b)
     }
-    #[lang = "u128_subo"]
-    pub fn rust_u128_subo(a: u128, b: u128) -> (u128, bool) {
+
+    pub extern "C" fn __rust_u128_subo(a: u128, b: u128) -> (u128, bool) {
         let mut oflow = 0;
         let r = a.subo(b, &mut oflow);
         (r, oflow != 0)

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -107,25 +107,14 @@ intrinsics! {
     pub extern "C" fn __muloti4(a: i128, b: i128, oflow: &mut i32) -> i128 {
         a.mulo(b, oflow)
     }
-}
 
-u128_lang_items! {
-    #[lang = "i128_mul"]
-    pub fn rust_i128_mul(a: i128, b: i128) -> i128 {
-        __multi3(a, b)
-    }
-    #[lang = "i128_mulo"]
-    pub fn rust_i128_mulo(a: i128, b: i128) -> (i128, bool) {
+    pub extern "C" fn __rust_i128_mulo(a: i128, b: i128) -> (i128, bool) {
         let mut oflow = 0;
         let r = __muloti4(a, b, &mut oflow);
         (r, oflow != 0)
     }
-    #[lang = "u128_mul"]
-    pub fn rust_u128_mul(a: u128, b: u128) -> u128 {
-        __multi3(a as _, b as _) as _
-    }
-    #[lang = "u128_mulo"]
-    pub fn rust_u128_mulo(a: u128, b: u128) -> (u128, bool) {
+
+    pub extern "C" fn __rust_u128_mulo(a: u128, b: u128) -> (u128, bool) {
         let mut oflow = 0;
         let r = a.mulo(b, &mut oflow);
         (r, oflow != 0)

--- a/src/int/sdiv.rs
+++ b/src/int/sdiv.rs
@@ -99,14 +99,3 @@ intrinsics! {
         a.divmod(b, rem, |a, b| __divdi3(a, b))
     }
 }
-
-u128_lang_items! {
-    #[lang = "i128_div"]
-    pub fn rust_i128_div(a: i128, b: i128) -> i128 {
-        __divti3(a, b)
-    }
-    #[lang = "i128_rem"]
-    pub fn rust_i128_rem(a: i128, b: i128) -> i128 {
-        __modti3(a, b)
-    }
-}

--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -103,40 +103,20 @@ intrinsics! {
     pub extern "C" fn __lshrti3(a: u128, b: u32) -> u128 {
         a.lshr(b)
     }
-}
 
-u128_lang_items! {
-    #[lang = "i128_shl"]
-    pub fn rust_i128_shl(a: i128, b: u32) -> i128 {
-        __ashlti3(a as _, b) as _
-    }
-    #[lang = "i128_shlo"]
-    pub fn rust_i128_shlo(a: i128, b: u128) -> (i128, bool) {
-        (rust_i128_shl(a, b as _), b >= 128)
-    }
-    #[lang = "u128_shl"]
-    pub fn rust_u128_shl(a: u128, b: u32) -> u128 {
-        __ashlti3(a, b)
-    }
-    #[lang = "u128_shlo"]
-    pub fn rust_u128_shlo(a: u128, b: u128) -> (u128, bool) {
-        (rust_u128_shl(a, b as _), b >= 128)
+    pub extern "C" fn __rust_i128_shlo(a: i128, b: u128) -> (i128, bool) {
+        (__ashlti3(a as _, b as _) as _, b >= 128)
     }
 
-    #[lang = "i128_shr"]
-    pub fn rust_i128_shr(a: i128, b: u32) -> i128 {
-        __ashrti3(a, b)
+    pub extern "C" fn __rust_u128_shlo(a: u128, b: u128) -> (u128, bool) {
+        (__ashlti3(a, b as _), b >= 128)
     }
-    #[lang = "i128_shro"]
-    pub fn rust_i128_shro(a: i128, b: u128) -> (i128, bool) {
-        (rust_i128_shr(a, b as _), b >= 128)
+
+    pub extern "C" fn __rust_i128_shro(a: i128, b: u128) -> (i128, bool) {
+        (__ashrti3(a, b as _), b >= 128)
     }
-    #[lang = "u128_shr"]
-    pub fn rust_u128_shr(a: u128, b: u32) -> u128 {
-        __lshrti3(a, b)
-    }
-    #[lang = "u128_shro"]
-    pub fn rust_u128_shro(a: u128, b: u128) -> (u128, bool) {
-        (rust_u128_shr(a, b as _), b >= 128)
+
+    pub extern "C" fn __rust_u128_shro(a: u128, b: u128) -> (u128, bool) {
+        (__lshrti3(a, b as _), b >= 128)
     }
 }

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -268,14 +268,3 @@ intrinsics! {
         udivmod_inner!(n, d, rem, u128)
     }
 }
-
-u128_lang_items! {
-    #[lang = "u128_div"]
-    pub fn rust_u128_div(a: u128, b: u128) -> u128 {
-        __udivti3(a, b)
-    }
-    #[lang = "u128_rem"]
-    pub fn rust_u128_rem(a: u128, b: u128) -> u128 {
-        __umodti3(a, b)
-    }
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -280,17 +280,3 @@ pub mod win64_128bit_abi_hack {
         }
     }
 }
-
-macro_rules! u128_lang_items {
-    ($(
-        #[lang = $lang:tt]
-        pub fn $name:ident( $($argname:ident:  $ty:ty),* ) -> $ret:ty {
-            $($body:tt)*
-        }
-    )*) => ($(
-        #[cfg_attr(not(any(stage0, feature = "no-lang-items")), lang = $lang)]
-        pub fn $name( $($argname:  $ty),* ) -> $ret {
-            $($body)*
-        }
-    )*)
-}

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -707,35 +707,35 @@ fn main() {
     // int/addsub.rs
     gen(
         |(a, b): (MyU128, MyU128)| Some(a.0.wrapping_add(b.0)),
-        "builtins::int::addsub::rust_u128_add(a, b)",
+        "builtins::int::addsub::__rust_u128_add(a, b)",
     );
     gen(
         |(a, b): (MyI128, MyI128)| Some(a.0.wrapping_add(b.0)),
-        "builtins::int::addsub::rust_i128_add(a, b)",
+        "builtins::int::addsub::__rust_i128_add(a, b)",
     );
     gen(
         |(a, b): (MyU128, MyU128)| Some(a.0.overflowing_add(b.0)),
-        "builtins::int::addsub::rust_u128_addo(a, b)",
+        "builtins::int::addsub::__rust_u128_addo(a, b)",
     );
     gen(
         |(a, b): (MyI128, MyI128)| Some(a.0.overflowing_add(b.0)),
-        "builtins::int::addsub::rust_i128_addo(a, b)",
+        "builtins::int::addsub::__rust_i128_addo(a, b)",
     );
     gen(
         |(a, b): (MyU128, MyU128)| Some(a.0.wrapping_sub(b.0)),
-        "builtins::int::addsub::rust_u128_sub(a, b)",
+        "builtins::int::addsub::__rust_u128_sub(a, b)",
     );
     gen(
         |(a, b): (MyI128, MyI128)| Some(a.0.wrapping_sub(b.0)),
-        "builtins::int::addsub::rust_i128_sub(a, b)",
+        "builtins::int::addsub::__rust_i128_sub(a, b)",
     );
     gen(
         |(a, b): (MyU128, MyU128)| Some(a.0.overflowing_sub(b.0)),
-        "builtins::int::addsub::rust_u128_subo(a, b)",
+        "builtins::int::addsub::__rust_u128_subo(a, b)",
     );
     gen(
         |(a, b): (MyI128, MyI128)| Some(a.0.overflowing_sub(b.0)),
-        "builtins::int::addsub::rust_i128_subo(a, b)",
+        "builtins::int::addsub::__rust_i128_subo(a, b)",
     );
 
     // int/mul.rs


### PR DESCRIPTION
The -Zlower-128bit-ops feature is completely broken, as libcore needs
those lang items to compile with this feature, but they are only
provided by compiler_builtins, which itself depends on libcore.
According to rust-lang/rust#58969 the feature never got finished.

This commit removes the associated lang items and replaces them with
normal unmangled functions, when there is no existing intrinsic. This
makes it easier for alternative codegen backends to implement 128bit
integer support.

cc https://github.com/bjorn3/rustc_codegen_cranelift/pull/627