### PR TITLE
probestack: add frame pointers for easier traceback

### DIFF
--- a/src/probestack.rs
+++ b/src/probestack.rs
@@ -53,6 +53,9 @@ pub unsafe extern "C" fn __rust_probestack() {
     // The ABI here is that the stack frame size is located in `%eax`. Upon
     // return we're not supposed to modify `%esp` or `%eax`.
     asm!("
+        pushq  %rbp
+        movq   %rsp, %rbp
+
         mov    %rax,%r11        // duplicate %rax as we're clobbering %r11
 
         // Main loop, taken in one page increments. We're decrementing rsp by
@@ -89,6 +92,7 @@ pub unsafe extern "C" fn __rust_probestack() {
         // return.
         add    %rax,%rsp
 
+        leave
         ret
     " ::: "memory" : "volatile");
     ::core::intrinsics::unreachable();
@@ -104,6 +108,8 @@ pub unsafe extern "C" fn __rust_probestack() {
     //
     // The ABI here is the same as x86_64, except everything is 32-bits large.
     asm!("
+        push   %ebp
+        mov    %esp, %ebp
         push   %ecx
         mov    %eax,%ecx
 
@@ -122,6 +128,7 @@ pub unsafe extern "C" fn __rust_probestack() {
 
         add    %eax,%esp
         pop    %ecx
+        leave
         ret
     " ::: "memory" : "volatile");
     ::core::intrinsics::unreachable();


### PR DESCRIPTION
This turns the following backtrace,

```
>> bt
 #0  0x0000555555576f73 in __rust_probestack () at /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.14/src/probestack.rs:55
Backtrace stopped: Cannot access memory at address 0x7fffff7fedf0
```

To this:

```
>>> bt
 #0  0x0000555555574e47 in __rust_probestack ()
 #1  0x00005555555595ba in test::main ()
 #2  0x00005555555594f3 in std::rt::lang_start::{{closure}} ()
 #3  0x0000555555561ae3 in std::panicking::try::do_call ()
 #4  0x000055555556595a in __rust_maybe_catch_panic ()
 #5  0x000055555555af9b in std::rt::lang_start_internal ()
 #6  0x00005555555594d5 in std::rt::lang_start ()
 #7  0x000055555555977b in main ()
```