### PR TITLE
Support deterministic builds by remapping the __FILE__ prefix if the …

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -423,6 +423,10 @@ mod c {
             panic!("RUST_COMPILER_RT_ROOT={} does not exist", root.display());
         }
 
+        // Support deterministic builds by remapping the __FILE__ prefix if the
+        // compiler supports it.
+        cfg.flag_if_supported(&format!("-ffile-prefix-map={}=.", root.display()));
+
         let src_dir = root.join("lib/builtins");
         for (sym, src) in sources.map.iter() {
             let src = src_dir.join(src);

--- a/build.rs
+++ b/build.rs
@@ -424,7 +424,8 @@ mod c {
         }
 
         // Support deterministic builds by remapping the __FILE__ prefix if the
-        // compiler supports it.
+        // compiler supports it.  This fixes the nondeterminism caused by the
+        // use of that macro in lib/builtins/int_util.h in compiler-rt.
         cfg.flag_if_supported(&format!("-ffile-prefix-map={}=.", root.display()));
 
         let src_dir = root.join("lib/builtins");


### PR DESCRIPTION
…compiler supports it.